### PR TITLE
Eddie lopez/mil 180 refactor to enable css class names to

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "scripts": {
         "start": "tsdx watch",
         "build": "tsdx build",
-        "test": "tsdx test --passWithNoTests",
+        "test": "tsdx test --passWithNoTests --maxWorkers=4",
         "lint": "yarn eslint src test stories",
         "prepare": "husky install; tsdx build",
         "size": "size-limit",

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -21,11 +21,12 @@ export interface Props extends HTMLAttributes<HTMLButtonElement> {
 export const Button: React.FC<Props> = ({
     children,
     href,
+    className = '',
     variant = 'default',
     ...props
 }: Props): JSX.Element => {
     const button: JSX.Element = (
-        <button {...props} className={`apollo-component-library-button ${variant}`}>
+        <button {...props} className={`apollo-component-library-button ${variant} ${className}`}>
             {children}
         </button>
     );

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -23,7 +23,7 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
  * @return ButtonGroup component
  */
 export const ButtonGroup: React.FC<Props> = ({
-    children,
+    children = '',
     variant = 'default',
     disabled = false,
     size = 'medium',

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -16,7 +16,7 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
  *
  * @return Card component
  */
-export const Card: React.FC<Props> = ({ children, ...props }: Props): JSX.Element => {
+export const Card: React.FC<Props> = ({ children, className, ...props }: Props): JSX.Element => {
     /**
      * Renderes all components
      *
@@ -40,15 +40,19 @@ export const Card: React.FC<Props> = ({ children, ...props }: Props): JSX.Elemen
 
         // return the structured content
         return (
-            <div {...props} className="apollo-component-library-card-component">
+            <>
                 {header}
                 <div className="apollo-component-library-card-component-body">
                     {formatted.getOther()}
                 </div>
                 {footer}
-            </div>
+            </>
         );
     };
 
-    return renderAll();
+    return (
+        <div {...props} className={`apollo-component-library-card-component ${className}`}>
+            {renderAll()}
+        </div>
+    );
 };

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -20,6 +20,7 @@ export interface Props extends HTMLAttributes<HTMLInputElement> {
  */
 export const Checkbox: React.FC<Props> = ({
     children,
+    className,
     disabled = false,
     ...props
 }: Props): JSX.Element => {
@@ -29,7 +30,7 @@ export const Checkbox: React.FC<Props> = ({
                 {...props}
                 type="checkbox"
                 disabled={disabled}
-                className="apollo-component-library-checkbox-component"
+                className={`apollo-component-library-checkbox-component ${className}`}
             />
             <Text inline margins>
                 {children}

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -15,7 +15,7 @@ export interface Props extends HTMLAttributes<HTMLHRElement> {
  */
 export const Divider: React.FC<Props> = ({
     color = 'lightgray',
-    className,
+    className = '',
     height = 1,
     style,
     ...props

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -42,7 +42,7 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
  */
 export const Drawer: React.FC<Props> = ({
     children,
-    className,
+    className = '',
     type = 'absolute',
     orientation = 'left',
     open = false,

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -26,6 +26,7 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
  */
 export const Dropdown: React.FC<Props> = ({
     children,
+    className = '',
     orientation = 'bottom',
     alignment = 'left',
     menuHeight,
@@ -81,5 +82,7 @@ export const Dropdown: React.FC<Props> = ({
         );
     };
 
-    return <span className="apollo-component-library-dropdown">{renderDropdown()}</span>;
+    return (
+        <span className={`apollo-component-library-dropdown ${className}`}>{renderDropdown()}</span>
+    );
 };

--- a/src/components/Dropdown/overload/Button.tsx
+++ b/src/components/Dropdown/overload/Button.tsx
@@ -11,6 +11,7 @@ const Button: React.FC<Overload<Props>> = ({
     parentProps: { dropdownRef, toggleOpen, open },
     onClick,
     children,
+    className = '',
     ...props
 }: Overload<Props>) => {
     /**
@@ -25,7 +26,7 @@ const Button: React.FC<Overload<Props>> = ({
     return (
         <span
             {...props}
-            className="apollo-component-library-dropdown-button-component"
+            className={`apollo-component-library-dropdown-button-component ${className}`}
             onClick={buttonOnClick}
             ref={dropdownRef}
         >

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -14,7 +14,7 @@ export interface Props extends Overload<HTMLAttributes<HTMLDivElement>> {
  */
 export const Footer: React.FC<Props> = ({
     children,
-    className,
+    className = '',
     parentProps,
     ...props
 }: Props): JSX.Element => {

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -90,9 +90,6 @@ export const Form: React.FC<Props> = ({
         const errors: string[] = [];
         // find if there are required fields not yet in valid map
         Object.keys(required).forEach((input: string) => {
-            // if (input === 'the-username' || input === 'the-password') {
-            //     console.log(input, validMap[input] === undefined, !formValue[input]);
-            // }
             if (validMap[input] === undefined || !formValue[input]) {
                 errors.push(required[input]);
             }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -14,7 +14,7 @@ export interface Props extends Overload<HTMLAttributes<HTMLDivElement>> {
  */
 export const Header: React.FC<Props> = ({
     children,
-    className,
+    className = '',
     parentProps,
     ...props
 }: Props): JSX.Element => {

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -27,6 +27,7 @@ export const Icon: React.FC<Props> = ({
     children,
     variant = 'default',
     color = 'black',
+    className = '',
     disabled,
     style,
     ...props
@@ -36,7 +37,7 @@ export const Icon: React.FC<Props> = ({
             {...props}
             style={getIconStyle(disabled, color, style)}
             className={`material-icons apollo-component-library-icon-component 
-                ${onClick && variant}`}
+                ${onClick && variant} ${className}`}
             onClick={onClick}
         >
             {name}

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -21,7 +21,7 @@ export const Label: React.FC<Props> = ({
     value,
     hint,
     children,
-    className,
+    className = '',
     ...props
 }: Props): JSX.Element => {
     // will keep track if label is parent to a required input
@@ -39,7 +39,7 @@ export const Label: React.FC<Props> = ({
     }, []);
 
     return (
-        <label className={`apollo-component-library-label-component ${className || ''}`} {...props}>
+        <label className={`apollo-component-library-label-component ${className}`} {...props}>
             {value?.length ? (
                 <Text bold style={labelStyle}>{`${value}${required ? '*' : ''}`}</Text>
             ) : null}

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -23,7 +23,7 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
  * @return Modal component
  */
 export const Modal: React.FC<Props> = ({
-    className,
+    className = '',
     manual = false,
     children,
     style,

--- a/src/components/Modal/overload/Button.tsx
+++ b/src/components/Modal/overload/Button.tsx
@@ -11,6 +11,7 @@ const Button: React.FC<Overload<Props>> = ({
     parentProps: { toggleModal, manual, open },
     onClick,
     variant,
+    className = '',
     ...props
 }: Overload<Props>): JSX.Element => {
     /**
@@ -27,7 +28,7 @@ const Button: React.FC<Overload<Props>> = ({
             {...props}
             onClick={buttonOnClick}
             className={`apollo-component-library-modal-component-button-group-button 
-                ${variant}`}
+                ${className} ${variant}`}
         />
     );
 };

--- a/src/components/Modal/overload/ButtonGroup.tsx
+++ b/src/components/Modal/overload/ButtonGroup.tsx
@@ -12,6 +12,7 @@ import { Props } from '../../ButtonGroup/ButtonGroup';
  */
 const ButtonGroup: React.FC<Overload<Props>> = ({
     parentProps: { children, ...parentProps },
+    className = '',
     ...props
 }: Overload<Props>) => {
     // get all props
@@ -25,7 +26,7 @@ const ButtonGroup: React.FC<Overload<Props>> = ({
         throw new Error('Only buttons are allowed in button groups');
 
     return (
-        <div className="apollo-component-library-modal-component-button-group">
+        <div className={`apollo-component-library-modal-component-button-group ${className}`}>
             {formattedButtonGroup.getAll()}
         </div>
     );

--- a/src/components/Option/Option.tsx
+++ b/src/components/Option/Option.tsx
@@ -20,10 +20,11 @@ export interface Props extends Overload<HTMLAttributes<HTMLElement>> {
 export const Option: React.FC<Props> = ({
     children,
     parentProps,
+    className = '',
     ...props
 }: Props): JSX.Element => {
     return (
-        <div {...props} className="apollo-component-library-option-component">
+        <div {...props} className={`apollo-component-library-option-component ${className}`}>
             <Text margins={false}>{children}</Text>
         </div>
     );

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -19,10 +19,14 @@ export interface Props extends HTMLAttributes<HTMLInputElement> {
  *
  * @return Radio component
  */
-export const Radio: React.FC<Props> = ({ children, ...props }: Props): JSX.Element => {
+export const Radio: React.FC<Props> = ({ children, className, ...props }: Props): JSX.Element => {
     return (
         <label>
-            <input {...props} type="radio" className="apollo-component-library-radio-component" />
+            <input
+                {...props}
+                type="radio"
+                className={`apollo-component-library-radio-component ${className}`}
+            />
             <Text inline margins>
                 {children}
             </Text>

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -28,6 +28,7 @@ export interface Props extends HTMLAttributes<HTMLInputElement> {
 export const Switch: React.FC<Props> = ({
     children,
     variant = 'default',
+    className = '',
     ...props
 }: Props): JSX.Element => {
     return (
@@ -38,7 +39,7 @@ export const Switch: React.FC<Props> = ({
                 role="switch"
                 className="apollo-component-library-switch-component-input"
             />
-            <span className={`apollo-component-library-switch-component ${variant}`} />
+            <span className={`apollo-component-library-switch-component ${variant} ${className}`} />
             <Text inline margins>
                 {children}
             </Text>

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -38,6 +38,7 @@ export interface Props extends HTMLAttributes<HTMLParagraphElement> {
  */
 export const Text: React.FC<Props> = ({
     children,
+    className = '',
     header = 0,
     margins = false,
     inline = false,
@@ -74,6 +75,9 @@ export const Text: React.FC<Props> = ({
         if (bold) customVariant += 'bold ';
         if (underline) customVariant += 'underline ';
         if (disabled) customVariant += 'disabled ';
+
+        // add className
+        customVariant += className;
 
         return customVariant;
     };

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -28,6 +28,7 @@ export interface Props extends HTMLAttributes<HTMLInputElement> {
  */
 export const TextInput: React.FC<Props> = ({
     variant = 'default',
+    className = '',
     password = false,
     valid = true,
     ...props
@@ -38,6 +39,7 @@ export const TextInput: React.FC<Props> = ({
             className={`apollo-component-library-text-input 
                 ${variant} 
                 ${valid ? 'valid' : 'invalid'}
+                ${className}
             `}
             type={password ? 'password' : 'text'}
         />


### PR DESCRIPTION
# Refactor to enable CSS class names to all Components
Some components, while they do have a property for the class name, it is never used. The task here is to go through all component files and fix these inconsistencies.