### PR TITLE
Ahmedpythondev/mil 407 chore give component props a descriptive

### DIFF
--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -2,7 +2,7 @@ import type { HTMLAttributes, ReactNode, FC } from 'react';
 import React from 'react';
 import './Alert.css';
 
-export interface Props extends HTMLAttributes<HTMLParagraphElement> {
+export interface IALert extends HTMLAttributes<HTMLParagraphElement> {
     /** Alert needs to exist between tags */
     children: ReactNode;
     /**
@@ -18,11 +18,11 @@ export interface Props extends HTMLAttributes<HTMLParagraphElement> {
  *
  * @return Alert component
  */
-export const Alert: FC<Props> = ({
+export const Alert: FC<IALert> = ({
     children,
     type = 'danger',
 
-    ...props
+    ...iAlert
 }) => {
     /**
      * Gets all the special conditions and translates it to a special className combination
@@ -44,7 +44,7 @@ export const Alert: FC<Props> = ({
     };
 
     return (
-        <div {...props} className={getVariant()}>
+        <div {...iAlert} className={getVariant()}>
             {children}
         </div>
     );

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import type { StyleVariant } from '../../interfaces/Properties';
 import './Button.css';
 
-export interface Props extends HTMLAttributes<HTMLButtonElement> {
+export interface IButton extends HTMLAttributes<HTMLButtonElement> {
     /** Required ReactNode that needs to exist between component tags */
     children: ReactNode;
     /** defines the type of button to be rendered */
@@ -19,15 +19,15 @@ export interface Props extends HTMLAttributes<HTMLButtonElement> {
  *
  * @return Button component
  */
-export const Button: FC<Props> = ({
+export const Button: FC<IButton> = ({
     children,
     href,
     className = '',
     variant = 'default',
-    ...props
+    ...iButton
 }) => {
     const button: JSX.Element = (
-        <button {...props} className={`apollo-component-library-button ${variant} ${className}`}>
+        <button {...iButton} className={`apollo-component-library-button ${variant} ${className}`}>
             {children}
         </button>
     );

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -7,7 +7,7 @@ import type { StyleVariant, ComponentSize } from '../../interfaces/Properties';
 
 import Button from './overload/Button';
 
-export interface Props extends HTMLAttributes<HTMLDivElement> {
+export interface IButtonGroup extends HTMLAttributes<HTMLDivElement> {
     /** Disables all buttons within button group */
     disabled?: boolean;
     /** toggle between different button group sizes */
@@ -23,13 +23,13 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
  *
  * @return ButtonGroup component
  */
-export const ButtonGroup: FC<Props> = ({
+export const ButtonGroup: FC<IButtonGroup> = ({
     children = '',
     variant = 'default',
     disabled = false,
     size = 'medium',
     className,
-    ...props
+    ...iButtonGroup
 }) => {
     /**
      * Renders all button group buttons and caches chlidren
@@ -46,7 +46,7 @@ export const ButtonGroup: FC<Props> = ({
     };
 
     return (
-        <div {...props} className={`apollo-component-library-button-group-component ${className}`}>
+        <div {...iButtonGroup} className={`apollo-component-library-button-group-component ${className}`}>
             {renderButtons()}
         </div>
     );

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -46,7 +46,10 @@ export const ButtonGroup: FC<IButtonGroup> = ({
     };
 
     return (
-        <div {...iButtonGroup} className={`apollo-component-library-button-group-component ${className}`}>
+        <div
+            {...iButtonGroup}
+            className={`apollo-component-library-button-group-component ${className}`}
+        >
             {renderButtons()}
         </div>
     );

--- a/src/components/ButtonGroup/overload/Button.tsx
+++ b/src/components/ButtonGroup/overload/Button.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Props } from '../../Button/Button';
+import { IButton } from '../../Button/Button';
 import Overload from '../../../interfaces/Overload';
 
 /**
@@ -7,16 +7,16 @@ import Overload from '../../../interfaces/Overload';
  *
  * @return ButtonGroup component
  */
-const Button: React.FC<Overload<Props>> = ({
+const Button: React.FC<Overload<IButton>> = ({
     parentProps: { disabled, variant, size },
     children,
     className,
     href,
-    ...props
-}: Overload<Props>): JSX.Element => {
+    ...iButton
+}: Overload<IButton>): JSX.Element => {
     return (
         <button
-            {...props}
+            {...iButton}
             disabled={disabled}
             className={`apollo-component-library-button-group-button-component 
                 ${className} 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -6,7 +6,7 @@ import './Card.css';
 import { Header } from '../Header/Header';
 import { Footer } from '../Footer/Footer';
 
-export interface Props extends HTMLAttributes<HTMLDivElement> {
+export interface ICard extends HTMLAttributes<HTMLDivElement> {
     /** Accepts any kind of children */
     children?: ReactNode;
 }
@@ -17,7 +17,7 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
  *
  * @return Card component
  */
-export const Card: FC<Props> = ({ children, className, ...props }) => {
+export const Card: FC<ICard> = ({ children, className, ...iCard }) => {
     /**
      * Renderes all components
      *
@@ -52,7 +52,7 @@ export const Card: FC<Props> = ({ children, className, ...props }) => {
     };
 
     return (
-        <div {...props} className={`apollo-component-library-card-component ${className}`}>
+        <div {...iCard} className={`apollo-component-library-card-component ${className}`}>
             {renderAll()}
         </div>
     );

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Text } from '../Text/Text';
 import './Checkbox.css';
 
-export interface Props extends HTMLAttributes<HTMLInputElement> {
+export interface ICheckbox extends HTMLAttributes<HTMLInputElement> {
     /** String that identifies the checkbox */
     id?: string;
     /**  Can have children between tags */
@@ -31,7 +31,7 @@ export interface Props extends HTMLAttributes<HTMLInputElement> {
  *
  * @return Checkbox component
  */
-export const Checkbox: FC<Props> = ({
+export const Checkbox: FC<ICheckbox> = ({
     inline = false,
     disabled = false,
     children,
@@ -40,7 +40,7 @@ export const Checkbox: FC<Props> = ({
     invalid,
     required,
     errorMessage,
-    ...props
+    ...iCheckbox
 }) => {
     // check if the user can use error messages
     useEffect(() => {
@@ -59,7 +59,7 @@ export const Checkbox: FC<Props> = ({
                 `}
             >
                 <input
-                    {...props}
+                    {...iCheckbox}
                     aria-required={required}
                     aria-invalid={invalid}
                     aria-errormessage={id ? `${id}-error` : undefined}

--- a/src/components/DateTimePicker/DateTimePicker.tsx
+++ b/src/components/DateTimePicker/DateTimePicker.tsx
@@ -6,7 +6,7 @@ import 'react-datepicker/dist/react-datepicker.css';
 
 import './DateTimePicker.css';
 
-export interface Props {
+export interface IDateTimePicker {
     /**
      * Determines format of date to be displayed
      * tag i.e. format=dd/MM/yyyy => 24/12/2020
@@ -26,7 +26,7 @@ export interface Props {
  *
  * @return DateTimePicker component
  */
-export const DateTimePicker: FC<Props> = ({
+export const DateTimePicker: FC<IDateTimePicker> = ({
     format = 'dd/MM/yyyy',
     mode = 'select',
     placeholder = 'Click to add a date',

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import * as CSS from 'csstype';
 import './Divider.css';
 
-export interface Props extends HTMLAttributes<HTMLHRElement> {
+export interface IDivider extends HTMLAttributes<HTMLHRElement> {
     /** color of desired divider */
     color?: CSS.Property.Color;
     /** height of divider in pixels */
@@ -15,11 +15,11 @@ export interface Props extends HTMLAttributes<HTMLHRElement> {
  *
  * @return Divider component
  */
-export const Divider: FC<Props> = ({ color, className = '', height, style, ...props }) => {
+export const Divider: FC<IDivider> = ({ color, className = '', height, style, ...iDivider }) => {
     return (
         <hr
             role="separator"
-            {...props}
+            {...iDivider}
             className={`apollo-component-library-divider-component ${className}`}
             style={getStyle(style, height, color)}
         />

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -8,7 +8,7 @@ import { Footer } from '../Footer/Footer';
 import Option from './overload/Option';
 import { ComponentOrientation } from '../../interfaces/Properties';
 
-export interface Props extends HTMLAttributes<HTMLDivElement> {
+export interface IDrawer extends HTMLAttributes<HTMLDivElement> {
     /**
      * Type of drawer that will be used. `absolute` assumes the drawer is in front of everything
      * and will use a backdrop. `persistent` will have a relative width and can push other
@@ -41,7 +41,7 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
  *
  * @return Drawer Component
  */
-export const Drawer: FC<Props> = ({
+export const Drawer: FC<IDrawer> = ({
     children,
     className = '',
     type = 'absolute',
@@ -52,7 +52,7 @@ export const Drawer: FC<Props> = ({
     onClose,
     toggleOpen,
     style,
-    ...props
+    ...iDrawer
 }) => {
     // ref
     const drawer = useRef<HTMLDivElement>(null);
@@ -129,7 +129,7 @@ export const Drawer: FC<Props> = ({
                     ${className} ${orientation} ${type}
                 `}
             >
-                <div {...props} ref={drawer} style={bodyStyle}>
+                <div {...iDrawer} ref={drawer} style={bodyStyle}>
                     {header}
                     <div className="apollo-component-library-drawer-component-body">
                         {formatted.getAll()}
@@ -180,7 +180,7 @@ const getBackdropStyle = (effect: boolean): React.CSSProperties => {
  * @param effect boolean that determines when to toggle dimension
  * @param dimension the scalar representing the size of the dimension
  * @param transition time in MS that it taks to close menu
- * @param style component css props
+ * @param style component css iDrawer
  * @return style object
  */
 const getDrawerContainerStyle = (
@@ -205,7 +205,7 @@ const getDrawerContainerStyle = (
  *
  * @param modifiedDimension string representing what dimension is being changed
  * @param dimension the scalar representing the size of the dimension
- * @param style component css props
+ * @param style component css iDrawer
  * @return style object
  */
 const getDrawerBodyStyle = (

--- a/src/components/Drawer/overload/Option.tsx
+++ b/src/components/Drawer/overload/Option.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Props, Option as COption } from '../../Option/Option';
+import { IOption, Option as COption } from '../../Option/Option';
 import Overload from '../../../interfaces/Overload';
 
 /**
@@ -7,9 +7,13 @@ import Overload from '../../../interfaces/Overload';
  *
  * @return Overloaded option
  */
-const Option: React.FC<Overload<Props>> = ({ style, children, ...props }: Overload<Props>) => {
+const Option: React.FC<Overload<IOption>> = ({
+    style,
+    children,
+    ...iOption
+}: Overload<IOption>) => {
     return (
-        <COption {...props} style={getOptionStyle(style)}>
+        <COption {...iOption} style={getOptionStyle(style)}>
             {children}
         </COption>
     );

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -10,7 +10,7 @@ import * as CSS from 'csstype';
 import { Option } from '../Option/Option';
 import type { ComponentAlignment, ComponentOrientation } from '../../interfaces/Properties';
 
-export interface Props extends HTMLAttributes<HTMLDivElement> {
+export interface IDropdown extends HTMLAttributes<HTMLDivElement> {
     /** Determines where the menu will appear from */
     orientation?: ComponentOrientation;
     /** Determines menu alignment, when orientation is left or right */
@@ -26,7 +26,7 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
  *
  * @return Dropdown component
  */
-export const Dropdown: FC<Props> = ({
+export const Dropdown: FC<IDropdown> = ({
     children,
     className = '',
     orientation = 'bottom',
@@ -46,7 +46,7 @@ export const Dropdown: FC<Props> = ({
      * @return dropdown component
      */
     const renderDropdown = (): JSX.Element => {
-        // define structured props
+        // define structured iDropdown
         const structured = {
             dropdownRef: dropdown,
             children,

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -46,7 +46,7 @@ export const Dropdown: FC<IDropdown> = ({
      * @return dropdown component
      */
     const renderDropdown = (): JSX.Element => {
-        // define structured iDropdown
+        // define structured props
         const structured = {
             dropdownRef: dropdown,
             children,

--- a/src/components/Dropdown/components/Menu.tsx
+++ b/src/components/Dropdown/components/Menu.tsx
@@ -1,8 +1,8 @@
 import type { HTMLAttributes, FC } from 'react';
 import React from 'react';
-import { Props as DropdownProps } from '../Dropdown';
+import { IDropdown as DropdownProps } from '../Dropdown';
 
-interface Props extends HTMLAttributes<HTMLDivElement>, DropdownProps {
+interface IMenu extends HTMLAttributes<HTMLDivElement>, DropdownProps {
     /** All options belonging to the menu */
     options: JSX.Element[];
 }
@@ -12,7 +12,7 @@ interface Props extends HTMLAttributes<HTMLDivElement>, DropdownProps {
  *
  * @return Menu with all options
  */
-const Menu: FC<Props> = ({ orientation, alignment, menuHeight, menuWidth, options }) => {
+const Menu: FC<IMenu> = ({ orientation, alignment, menuHeight, menuWidth, options }) => {
     // define styling options
     const style: { [key: string]: string | number } = {};
 

--- a/src/components/Dropdown/overload/Button.tsx
+++ b/src/components/Dropdown/overload/Button.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Props } from '../../Button/Button';
+import { IButton } from '../../Button/Button';
 import Overload from '../../../interfaces/Overload';
 
 /**
@@ -7,13 +7,13 @@ import Overload from '../../../interfaces/Overload';
  *
  * @return overloaded dropdown button
  */
-const Button: React.FC<Overload<Props>> = ({
+const Button: React.FC<Overload<IButton>> = ({
     parentProps: { dropdownRef, toggleOpen, open },
     onClick,
     children,
     className = '',
     ...props
-}: Overload<Props>) => {
+}: Overload<IButton>) => {
     /**
      * Modifies the original button onClick so that it can also open and
      * close the menu

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Overload from '../../interfaces/Overload';
 import './Footer.css';
 
-export interface Props extends Overload<HTMLAttributes<HTMLDivElement>> {
+export interface IFooter extends Overload<HTMLAttributes<HTMLDivElement>> {
     /** Can have children of any kind */
     children?: ReactNode;
 }
@@ -13,9 +13,9 @@ export interface Props extends Overload<HTMLAttributes<HTMLDivElement>> {
  *
  * @return Footer component
  */
-export const Footer: FC<Props> = ({ children, className = '', parentProps, ...props }) => {
+export const Footer: FC<IFooter> = ({ children, className = '', parentProps, ...iFooter }) => {
     return (
-        <div {...props} className={`apollo-component-library-footer-component ${className}`}>
+        <div {...iFooter} className={`apollo-component-library-footer-component ${className}`}>
             {children}
         </div>
     );

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -9,7 +9,7 @@ import type {
 import CSForm from './components/CSForm';
 import SSForm from './components/SSForm';
 
-export interface Props extends Omit<HTMLAttributes<HTMLFormElement>, 'onSubmit' | 'onError'> {
+export interface IForm extends Omit<HTMLAttributes<HTMLFormElement>, 'onSubmit' | 'onError'> {
     /** Handles form submission with object derived from form */
     onSubmit?: FormSubmitHandler;
     /** Handles errors from form submission with error object */
@@ -24,7 +24,7 @@ export interface Props extends Omit<HTMLAttributes<HTMLFormElement>, 'onSubmit' 
  *
  * @return form Component based on type
  */
-export const Form: FC<Props> = ({ type = 'client', ...props }) => {
+export const Form: FC<IForm> = ({ type = 'client', ...iFrom }) => {
     /**
      * Based on the type, this method will choose what form to render
      *
@@ -33,10 +33,10 @@ export const Form: FC<Props> = ({ type = 'client', ...props }) => {
     const renderForm = (): JSX.Element => {
         switch (type) {
             case 'remix':
-                const { onSubmit, onError, ...rest } = props;
+                const { onSubmit, onError, ...rest } = iFrom;
                 return <SSForm {...rest} />;
             default:
-                return <CSForm {...props} />;
+                return <CSForm {...iFrom} />;
         }
     };
 

--- a/src/components/Form/components/CSForm.tsx
+++ b/src/components/Form/components/CSForm.tsx
@@ -11,7 +11,7 @@ import Radio from '../overload/CSRadio';
 import Switch from '../overload/CSSwitch';
 import Checkbox from '../overload/CSCheckbox';
 
-export interface Props extends Omit<HTMLAttributes<HTMLFormElement>, 'onSubmit' | 'onError'> {
+export interface ICSForm extends Omit<HTMLAttributes<HTMLFormElement>, 'onSubmit' | 'onError'> {
     /** Handles form submission with object derived from form */
     onSubmit?: FormSubmitHandler;
     /** Handles errors from form submission with error object */
@@ -23,7 +23,7 @@ export interface Props extends Omit<HTMLAttributes<HTMLFormElement>, 'onSubmit' 
  *
  * @return client side form
  */
-const CSForm: FC<Props> = ({ onSubmit, onError, children, ...props }) => {
+const CSForm: FC<ICSForm> = ({ onSubmit, onError, children, ...iCSForm }) => {
     // use the use form hoook
     const {
         setError,
@@ -39,7 +39,7 @@ const CSForm: FC<Props> = ({ onSubmit, onError, children, ...props }) => {
      * Formats and renders all children component
      *
      * @param childrenProp children property to be passed by render all
-     * @param passthrough parent props to be passed through the original parents
+     * @param passthrough parent iCSForm to be passed through the original parents
      * @return formatted children
      */
     const renderAll = (
@@ -81,7 +81,7 @@ const CSForm: FC<Props> = ({ onSubmit, onError, children, ...props }) => {
     };
 
     return (
-        <form {...props} onSubmit={handleSubmission}>
+        <form {...iCSForm} onSubmit={handleSubmission}>
             {renderAll(children)}
         </form>
     );

--- a/src/components/Form/components/SSForm.tsx
+++ b/src/components/Form/components/SSForm.tsx
@@ -10,7 +10,7 @@ import Radio from '../overload/SSRadio';
 import Switch from '../overload/SSSwitch';
 import Group from '../overload/SSGroup';
 
-interface Props extends HTMLAttributes<HTMLFormElement> {
+interface ISSForm extends HTMLAttributes<HTMLFormElement> {
     /** Object describing the behavior of the form */
     actionData?: FormActionData;
 }
@@ -20,7 +20,7 @@ interface Props extends HTMLAttributes<HTMLFormElement> {
  *
  * @return Formatted Form component
  */
-const SSForm: FC<Props> = ({ actionData, children, ...props }) => {
+const SSForm: FC<ISSForm> = ({ actionData, children, ...iSSForm }) => {
     /**
      * Renders all formatted children component
      *
@@ -44,7 +44,7 @@ const SSForm: FC<Props> = ({ actionData, children, ...props }) => {
         return formatted.getAll();
     };
 
-    return <form {...props}>{renderAll()}</form>;
+    return <form {...iSSForm}>{renderAll()}</form>;
 };
 
 export default SSForm;

--- a/src/components/Form/overload/CSCheckbox.tsx
+++ b/src/components/Form/overload/CSCheckbox.tsx
@@ -4,9 +4,9 @@ import React, { useEffect } from 'react';
 import Overload from '../../../interfaces/Overload';
 import { FormToggleData } from '../../../interfaces/Properties';
 
-import { Checkbox as CCheckbox, Props as CheckboxProps } from '../../Checkbox/Checkbox';
+import { Checkbox as CCheckbox, ICheckbox as CheckboxProps } from '../../Checkbox/Checkbox';
 
-interface Props extends Overload<CheckboxProps> {
+interface ICheckbox extends Overload<CheckboxProps> {
     id: string;
 }
 
@@ -15,12 +15,12 @@ interface Props extends Overload<CheckboxProps> {
  *
  * @return Formatted Checkbox compatible with form
  */
-const Checkbox: FC<Props> = ({
+const Checkbox: FC<ICheckbox> = ({
     parentProps: { register, setValue, clearErrors, errors },
     onChange,
     required,
     id,
-    ...props
+    ...iCheckbox
 }) => {
     // make sure that an id was provided
     useEffect(() => {
@@ -52,7 +52,7 @@ const Checkbox: FC<Props> = ({
 
     return (
         <CCheckbox
-            {...props}
+            {...iCheckbox}
             id={id}
             required={required}
             onChange={handleChange}

--- a/src/components/Form/overload/CSGroup.tsx
+++ b/src/components/Form/overload/CSGroup.tsx
@@ -4,9 +4,9 @@ import React, { useEffect } from 'react';
 import Overload from '../../../interfaces/Overload';
 import { FormGroupData } from '../../../interfaces/Properties';
 
-import { Group as CGroup, Props as GroupProps } from '../../Group/Group';
+import { Group as CGroup, IGroup as GroupProps } from '../../Group/Group';
 
-interface Props extends Overload<GroupProps> {
+interface IGroup extends Overload<GroupProps> {
     /** Name is required for text inputs inside of form, having none will throw */
     name: string;
 }
@@ -16,7 +16,7 @@ interface Props extends Overload<GroupProps> {
  *
  * @return formatted group component
  */
-const Group: FC<Props> = ({
+const Group: FC<IGroup> = ({
     parentProps: { register, setError, setValue, clearErrors, errors, getValues, renderAll },
     children,
     name,
@@ -25,7 +25,7 @@ const Group: FC<Props> = ({
     label,
     onChange,
     type,
-    ...props
+    ...iGroup
 }) => {
     useEffect(() => {
         if (type === 'organization') return;
@@ -124,7 +124,7 @@ const Group: FC<Props> = ({
 
     return (
         <CGroup
-            {...props}
+            {...iGroup}
             required={required}
             type={type}
             label={label}

--- a/src/components/Form/overload/CSRadio.tsx
+++ b/src/components/Form/overload/CSRadio.tsx
@@ -4,9 +4,9 @@ import React, { useEffect } from 'react';
 import Overload from '../../../interfaces/Overload';
 import { FormToggleData } from '../../../interfaces/Properties';
 
-import { Radio as CRadio, Props as RadioProps } from '../../Radio/Radio';
+import { Radio as CRadio, IRadio as RadioProps } from '../../Radio/Radio';
 
-interface Props extends Overload<RadioProps> {
+interface IRadio extends Overload<RadioProps> {
     id: string;
 }
 
@@ -15,12 +15,12 @@ interface Props extends Overload<RadioProps> {
  *
  * @return Formatted Radio compatible with form
  */
-const Radio: FC<Props> = ({
+const Radio: FC<IRadio> = ({
     parentProps: { register, setValue, clearErrors, errors },
     onChange,
     required,
     id,
-    ...props
+    ...iRadio
 }) => {
     // make sure that an id was provided
     useEffect(() => {
@@ -52,7 +52,7 @@ const Radio: FC<Props> = ({
 
     return (
         <CRadio
-            {...props}
+            {...iRadio}
             id={id}
             required={required}
             onChange={handleChange}

--- a/src/components/Form/overload/CSSwitch.tsx
+++ b/src/components/Form/overload/CSSwitch.tsx
@@ -4,7 +4,7 @@ import React, { useEffect } from 'react';
 import Overload from '../../../interfaces/Overload';
 import { FormToggleData } from '../../../interfaces/Properties';
 
-import { Switch as CSwitch, Props as SwitchProps } from '../../Switch/Switch';
+import { Switch as CSwitch, ISwitch as SwitchProps } from '../../Switch/Switch';
 
 /**
  * Switch component formatted to integrate with form component
@@ -14,7 +14,7 @@ import { Switch as CSwitch, Props as SwitchProps } from '../../Switch/Switch';
 const Switch: FC<Overload<SwitchProps>> = ({
     parentProps: { setValue, register },
     name,
-    ...props
+    ...iSwitch
 }) => {
     // make sure that an id was provided
     useEffect(() => {
@@ -39,7 +39,7 @@ const Switch: FC<Overload<SwitchProps>> = ({
         setValue(name, data);
     };
 
-    return <CSwitch {...props} name={name} onChange={handleChange} />;
+    return <CSwitch {...iSwitch} name={name} onChange={handleChange} />;
 };
 
 export default Switch;

--- a/src/components/Form/overload/CSTextInput.tsx
+++ b/src/components/Form/overload/CSTextInput.tsx
@@ -3,9 +3,9 @@ import React, { useEffect } from 'react';
 import Overload from '../../../interfaces/Overload';
 import { FormTextData } from '../../../interfaces/Properties';
 
-import { TextInput as CTextInput, Props as TextInputProps } from '../../TextInput/TextInput';
+import { TextInput as CTextInput, ITextInput as TextInputProps } from '../../TextInput/TextInput';
 
-interface Props extends Overload<TextInputProps> {
+interface ITextInput extends Overload<TextInputProps> {
     /** Name is required for text inputs inside of form, having none will throw */
     name: string;
 }
@@ -15,14 +15,14 @@ interface Props extends Overload<TextInputProps> {
  *
  * @return formatted text input
  */
-const TextInput: FC<Props> = ({
+const TextInput: FC<ITextInput> = ({
     parentProps: { register, setValue, setError, clearErrors, errors },
     name,
     required,
     label,
     validator,
     onChange,
-    ...props
+    ...iTextInput
 }) => {
     // when using the client side form, we want to enforce names
     useEffect(() => {
@@ -83,7 +83,7 @@ const TextInput: FC<Props> = ({
 
     return (
         <CTextInput
-            {...props}
+            {...iTextInput}
             required={required}
             name={name}
             label={label}

--- a/src/components/Form/overload/SSCheckbox.tsx
+++ b/src/components/Form/overload/SSCheckbox.tsx
@@ -3,9 +3,9 @@ import React from 'react';
 
 import Overload from '../../../interfaces/Overload';
 
-import { Checkbox as CCheckbox, Props as CheckboxProps } from '../../Checkbox/Checkbox';
+import { Checkbox as CCheckbox, ICheckbox as CheckboxProps } from '../../Checkbox/Checkbox';
 
-interface Props extends Overload<CheckboxProps> {
+interface ICheckbox extends Overload<CheckboxProps> {
     id: string;
 }
 
@@ -14,7 +14,7 @@ interface Props extends Overload<CheckboxProps> {
  *
  * @return Formatted Checkbox compatible with form
  */
-const Checkbox: FC<Props> = ({
+const Checkbox: FC<ICheckbox> = ({
     parentProps: {
         groupName,
         actionData: { fields, fieldErrors },
@@ -25,7 +25,7 @@ const Checkbox: FC<Props> = ({
     value,
     inline,
     id,
-    ...props
+    ...iCheckbox
 }) => {
     const isChecked: boolean = fields
         ? groupName?.length
@@ -37,7 +37,7 @@ const Checkbox: FC<Props> = ({
 
     return (
         <CCheckbox
-            {...props}
+            {...iCheckbox}
             id={id}
             inline={groupInline || inline}
             value={value}

--- a/src/components/Form/overload/SSGroup.tsx
+++ b/src/components/Form/overload/SSGroup.tsx
@@ -4,22 +4,22 @@ import React, { useEffect } from 'react';
 import Overload from '../../../interfaces/Overload';
 import FormatChildren from '../../../util/FormatChildren';
 
-import type { Props as GroupProps } from '../../Group/Group';
+import type { IGroup as GroupProps } from '../../Group/Group';
 import { Text } from '../../Text/Text';
 
 import Radio from './SSRadio';
 import Checkbox from './SSCheckbox';
 
-interface Props extends Overload<GroupProps> {
+interface IGroup extends Overload<GroupProps> {
     name: string;
 }
 
 /**
- * Formatted Group, will serve as passthrough for parent props when in remix validation mode
+ * Formatted Group, will serve as passthrough for parent iGroup when in remix validation mode
  *
  * @return formatted group that complies with remix validation
  */
-const Group: FC<Props> = ({
+const Group: FC<IGroup> = ({
     parentProps: { actionData = { fields: {}, fieldErrors: {} } },
     type = 'input',
     disabled = false,
@@ -30,7 +30,7 @@ const Group: FC<Props> = ({
     label,
     hint,
     required,
-    ...props
+    ...iGroup
 }) => {
     useEffect(() => {
         if (type === 'organization') return;
@@ -39,7 +39,7 @@ const Group: FC<Props> = ({
     });
 
     /**
-     * Formats children components and passes the parent props through
+     * Formats children components and passes the parent iGroup through
      *
      * @return formatted children
      */
@@ -56,7 +56,7 @@ const Group: FC<Props> = ({
     return (
         <>
             <fieldset
-                {...props}
+                {...iGroup}
                 className={`apollo-component-library-group ${invalid ? 'invalid' : ''}`}
                 aria-errormessage={name ? `${name}-error` : undefined}
                 aria-invalid={invalid}

--- a/src/components/Form/overload/SSRadio.tsx
+++ b/src/components/Form/overload/SSRadio.tsx
@@ -3,9 +3,9 @@ import React from 'react';
 
 import Overload from '../../../interfaces/Overload';
 
-import { Radio as CRadio, Props as RadioProps } from '../../Radio/Radio';
+import { Radio as CRadio, IRadio as RadioProps } from '../../Radio/Radio';
 
-interface Props extends Overload<RadioProps> {
+interface IRadio extends Overload<RadioProps> {
     id: string;
 }
 
@@ -14,7 +14,7 @@ interface Props extends Overload<RadioProps> {
  *
  * @return Formatted Radio compatible with form
  */
-const Radio: FC<Props> = ({
+const Radio: FC<IRadio> = ({
     parentProps: {
         groupName,
         actionData: { fields, fieldErrors },
@@ -26,7 +26,7 @@ const Radio: FC<Props> = ({
     value,
     inline,
     id,
-    ...props
+    ...iRadio
 }) => {
     const isChecked: boolean = fields
         ? groupName?.length
@@ -38,7 +38,7 @@ const Radio: FC<Props> = ({
 
     return (
         <CRadio
-            {...props}
+            {...iRadio}
             id={id}
             value={value}
             inline={groupInline || inline}

--- a/src/components/Form/overload/SSSwitch.tsx
+++ b/src/components/Form/overload/SSSwitch.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import Overload from '../../../interfaces/Overload';
 
-import { Switch as CSwitch, Props as SwitchProps } from '../../Switch/Switch';
+import { Switch as CSwitch, ISwitch as SwitchProps } from '../../Switch/Switch';
 
 /**
  * Formats Switch to be compatible with form
@@ -18,12 +18,12 @@ const Switch: FC<Overload<SwitchProps>> = ({
     required,
     name,
     id,
-    ...props
+    ...iSwitch
 }) => {
     const isChecked: boolean = fields ? fields[name] : false;
 
     return (
-        <CSwitch {...props} id={id} name={name} required={required} defaultChecked={isChecked} />
+        <CSwitch {...iSwitch} id={id} name={name} required={required} defaultChecked={isChecked} />
     );
 };
 

--- a/src/components/Form/overload/SSTextInput.tsx
+++ b/src/components/Form/overload/SSTextInput.tsx
@@ -3,10 +3,10 @@ import React from 'react';
 
 import type Overload from '../../../interfaces/Overload';
 
-import type { Props as TextInputProps } from '../../TextInput/TextInput';
+import type { ITextInput as TextInputProps } from '../../TextInput/TextInput';
 import { TextInput as CTextInput } from '../../TextInput/TextInput';
 
-interface Props extends Overload<TextInputProps> {
+interface ITextInput extends Overload<TextInputProps> {
     name: string;
 }
 
@@ -15,14 +15,14 @@ interface Props extends Overload<TextInputProps> {
  *
  * @return formatted text input for remix validation
  */
-const SSTextInput: FC<Props> = ({ name, parentProps: { actionData }, ...props }) => {
+const SSTextInput: FC<ITextInput> = ({ name, parentProps: { actionData }, ...iTextInput }) => {
     const defaultValue = actionData?.fields ? actionData?.fields[name] : undefined;
 
     const errorMessage = actionData?.fieldErrors ? actionData?.fieldErrors[name] : undefined;
 
     return (
         <CTextInput
-            {...props}
+            {...iTextInput}
             name={name}
             defaultValue={defaultValue}
             invalid={Boolean(errorMessage?.length)}

--- a/src/components/Group/Group.tsx
+++ b/src/components/Group/Group.tsx
@@ -9,7 +9,7 @@ import Checkbox from './overload/Checkbox';
 import View from './overload/View';
 import { FormGroupData, FormValidator } from '../../interfaces/Properties';
 
-export interface Props extends Omit<HTMLAttributes<HTMLFieldSetElement>, 'onChange'> {
+export interface IGroup extends Omit<HTMLAttributes<HTMLFieldSetElement>, 'onChange'> {
     /** Group must contain element between tags */
     children: ReactNode;
     /** Identifies the group's selection */
@@ -46,7 +46,7 @@ export interface Props extends Omit<HTMLAttributes<HTMLFieldSetElement>, 'onChan
  *
  * @return Group component
  */
-export const Group: FC<Props> = ({
+export const Group: FC<IGroup> = ({
     type = 'input',
     disabled = false,
     inline = false,
@@ -58,7 +58,7 @@ export const Group: FC<Props> = ({
     required,
     invalid,
     errorMessage,
-    ...props
+    ...iGroup
 }) => {
     // check if the user is using error message invalidly
     useEffect(() => {
@@ -95,7 +95,7 @@ export const Group: FC<Props> = ({
     return (
         <>
             <fieldset
-                {...props}
+                {...iGroup}
                 className={`apollo-component-library-group ${invalid ? 'invalid' : ''}`}
                 aria-errormessage={name ? `${name}-error` : undefined}
                 aria-invalid={invalid}

--- a/src/components/Group/overload/Checkbox.tsx
+++ b/src/components/Group/overload/Checkbox.tsx
@@ -1,6 +1,6 @@
 import type { ChangeEvent, FC } from 'react';
 import React from 'react';
-import { Props, Checkbox as CCheckbox } from '../../Checkbox/Checkbox';
+import { ICheckbox, Checkbox as CCheckbox } from '../../Checkbox/Checkbox';
 import Overload from '../../../interfaces/Overload';
 
 /**
@@ -8,14 +8,14 @@ import Overload from '../../../interfaces/Overload';
  *
  * @return Formatted Checkbox
  */
-const Checkbox: FC<Overload<Props>> = ({
+const Checkbox: FC<Overload<ICheckbox>> = ({
     parentProps: { name, onChange: groupOnChange, disabled: parentDisabled, inline: parentInline },
     onChange,
     disabled,
     value,
     inline,
-    ...props
-}: Overload<Props>): JSX.Element => {
+    ...iCheckbox
+}: Overload<ICheckbox>): JSX.Element => {
     /**
      * Updates value and fires original onChange method
      *
@@ -31,7 +31,7 @@ const Checkbox: FC<Overload<Props>> = ({
 
     return (
         <CCheckbox
-            {...props}
+            {...iCheckbox}
             value={value}
             name={name}
             inline={parentInline}

--- a/src/components/Group/overload/Radio.tsx
+++ b/src/components/Group/overload/Radio.tsx
@@ -1,6 +1,6 @@
 import type { ChangeEvent, FC } from 'react';
 import React from 'react';
-import { Props, Radio as CRadio } from '../../Radio/Radio';
+import { IRadio, Radio as CRadio } from '../../Radio/Radio';
 import Overload from '../../../interfaces/Overload';
 
 /**
@@ -8,14 +8,14 @@ import Overload from '../../../interfaces/Overload';
  *
  * @return Formatted Radio
  */
-const Radio: FC<Overload<Props>> = ({
+const Radio: FC<Overload<IRadio>> = ({
     parentProps: { disabled: parentDisabled, onChange: groupOnChange, name, inline: parentInline },
     onChange,
     disabled,
     value,
     inline,
-    ...props
-}: Overload<Props>): JSX.Element => {
+    ...iRadio
+}: Overload<IRadio>): JSX.Element => {
     /**
      * Updates value and fires original onChange method
      *
@@ -31,7 +31,7 @@ const Radio: FC<Overload<Props>> = ({
 
     return (
         <CRadio
-            {...props}
+            {...iRadio}
             name={name}
             value={value}
             inline={parentInline}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Overload from '../../interfaces/Overload';
 import './Header.css';
 
-export interface Props extends Overload<HTMLAttributes<HTMLDivElement>> {
+export interface IHeader extends Overload<HTMLAttributes<HTMLDivElement>> {
     /** Can have children of any kind */
     children?: ReactNode;
 }
@@ -13,9 +13,9 @@ export interface Props extends Overload<HTMLAttributes<HTMLDivElement>> {
  *
  * @return Header component
  */
-export const Header: FC<Props> = ({ children, className = '', parentProps, ...props }) => {
+export const Header: FC<IHeader> = ({ children, className = '', parentProps, ...iHeader }) => {
     return (
-        <div {...props} className={`apollo-component-library-header-component ${className}`}>
+        <div {...iHeader} className={`apollo-component-library-header-component ${className}`}>
             {children}
         </div>
     );

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react';
 import * as CSS from 'csstype';
 import './Icon.css';
 
-export interface Props extends HTMLAttributes<HTMLParagraphElement> {
+export interface IIcon extends HTMLAttributes<HTMLParagraphElement> {
     /** The icon name the user wants to render */
     name: string;
     /** Specification of an onClick method will convert icon into a button */
@@ -25,7 +25,7 @@ export interface Props extends HTMLAttributes<HTMLParagraphElement> {
  *
  * @return Icon component
  */
-export const Icon: FC<Props> = ({
+export const Icon: FC<IIcon> = ({
     name,
     onClick,
     clickable = onClick && true,
@@ -35,7 +35,7 @@ export const Icon: FC<Props> = ({
     className = '',
     disabled,
     style,
-    ...props
+    ...iIcon
 }) => {
     useEffect(() => {
         if (!onClick) return;
@@ -57,7 +57,7 @@ export const Icon: FC<Props> = ({
 
     return (
         <span
-            {...props}
+            {...iIcon}
             style={getIconStyle(disabled, color, style)}
             tabIndex={onClick ? 0 : undefined}
             className={`material-icons apollo-component-library-icon-component 

--- a/src/components/LoadingState/LoadingState.tsx
+++ b/src/components/LoadingState/LoadingState.tsx
@@ -2,7 +2,7 @@ import type { HTMLAttributes, FC } from 'react';
 import React, { useState, useEffect, ReactNode, useRef, CSSProperties } from 'react';
 import './LoadingState.css';
 
-export interface Props extends HTMLAttributes<HTMLDivElement> {
+export interface ILoadingState extends HTMLAttributes<HTMLDivElement> {
     /**
      * Determines status of the progressbar where
      * progressFilled={0.1} => 10% filled progressbar
@@ -21,7 +21,7 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
  *
  * @return LoadingState component
  */
-export const LoadingState: FC<Props> = ({
+export const LoadingState: FC<ILoadingState> = ({
     progress = 0,
     type = 'spinner',
     size = 'small',
@@ -29,7 +29,7 @@ export const LoadingState: FC<Props> = ({
     className,
     children = undefined,
     style,
-    ...props
+    ...iLoadingState
 }) => {
     // ref
     const progressRef = useRef<HTMLHeadingElement>(null);
@@ -67,13 +67,13 @@ export const LoadingState: FC<Props> = ({
 
         const loadingStyle: CSSProperties = {};
 
-        // give appropriate aria-props
+        // give appropriate aria-iLoadingState
         const ariaProps: { [key: string]: string } = {};
         if (type === 'progress') {
             // assign width
             loadingStyle.width = width * progress;
 
-            // assign aria props
+            // assign aria iLoadingState
             ariaProps.role = 'progressbar';
             ariaProps['aria-valuenow'] = `${progress * 100}`;
             ariaProps['aria-valuemax'] = '100';
@@ -86,7 +86,7 @@ export const LoadingState: FC<Props> = ({
         return (
             <div {...ariaProps} className={containerName} ref={progressRef}>
                 <div
-                    {...props}
+                    {...iLoadingState}
                     style={loadingStyle}
                     className={`
                         ${loadingType}

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -4,7 +4,7 @@ import './Modal.css';
 
 import Dialog from './components/Dialog';
 
-export interface Props extends HTMLAttributes<HTMLDivElement> {
+export interface IModal extends HTMLAttributes<HTMLDivElement> {
     /** Required ID for WCAG 2.0 compliance purposes */
     id: string;
     /** Requires descriptive label for WCAG 2.0 compliance purposes */
@@ -29,13 +29,13 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
  *
  * @return Modal component
  */
-export const Modal: FC<Props> = ({
+export const Modal: FC<IModal> = ({
     className = '',
     manual = false,
     open = false,
     style,
     toggleModal,
-    ...props
+    ...iModal
 }) => {
     // state variables
     const [display, toggleDisplay] = useState(open);
@@ -64,7 +64,7 @@ export const Modal: FC<Props> = ({
                     <div className="apollo-component-library-modal-component-backdrop">
                         {
                             <Dialog
-                                {...props}
+                                {...iModal}
                                 className={className}
                                 open={open}
                                 manual={manual}

--- a/src/components/Modal/components/Dialog.tsx
+++ b/src/components/Modal/components/Dialog.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 
 import FormatChildren from '../../../util/FormatChildren';
 
-import type { IDialog } from '../Modal';
+import type { IModal } from '../Modal';
 import Footer from '../overload/Footer';
 import { Header } from '../../Header/Header';
 import { Text } from '../../Text/Text';
@@ -14,7 +14,7 @@ import { Icon } from '../../Icon/Icon';
  *
  * @return Modal dialog element
  */
-const Dialog: FC<IDialog> = ({
+const Dialog: FC<IModal> = ({
     className,
     manual,
     toggleModal,
@@ -24,7 +24,7 @@ const Dialog: FC<IDialog> = ({
     label,
     id,
     children,
-    ...iDialog
+    ...iModal
 }) => {
     const [formatted, setFormatted] = useState<FormatChildren | undefined>();
 
@@ -75,7 +75,7 @@ const Dialog: FC<IDialog> = ({
 
     return (
         <div
-            {...iDialog}
+            {...iModal}
             id={id}
             role={alert ? 'alertdialog' : 'dialog'}
             aria-modal="true"

--- a/src/components/Modal/components/Dialog.tsx
+++ b/src/components/Modal/components/Dialog.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 
 import FormatChildren from '../../../util/FormatChildren';
 
-import type { Props } from '../Modal';
+import type { IDialog } from '../Modal';
 import Footer from '../overload/Footer';
 import { Header } from '../../Header/Header';
 import { Text } from '../../Text/Text';
@@ -14,7 +14,7 @@ import { Icon } from '../../Icon/Icon';
  *
  * @return Modal dialog element
  */
-const Dialog: FC<Props> = ({
+const Dialog: FC<IDialog> = ({
     className,
     manual,
     toggleModal,
@@ -24,7 +24,7 @@ const Dialog: FC<Props> = ({
     label,
     id,
     children,
-    ...props
+    ...iDialog
 }) => {
     const [formatted, setFormatted] = useState<FormatChildren | undefined>();
 
@@ -75,7 +75,7 @@ const Dialog: FC<Props> = ({
 
     return (
         <div
-            {...props}
+            {...iDialog}
             id={id}
             role={alert ? 'alertdialog' : 'dialog'}
             aria-modal="true"

--- a/src/components/Modal/overload/Button.tsx
+++ b/src/components/Modal/overload/Button.tsx
@@ -1,20 +1,20 @@
 import type { FC } from 'react';
 import React from 'react';
 import Overload from '../../../interfaces/Overload';
-import { Props } from '../../Button/Button';
+import { IButton } from '../../Button/Button';
 
 /**
  * Overloaded Button that is formatted to use modal functions on click
  *
  * @return Button component
  */
-const Button: FC<Overload<Props>> = ({
+const Button: FC<Overload<IButton>> = ({
     parentProps: { toggleModal, manual, open },
     onClick,
     variant,
     className = '',
-    ...props
-}: Overload<Props>): JSX.Element => {
+    ...iButton
+}: Overload<IButton>): JSX.Element => {
     /**
      * Will toggle the modal to close after executing original on click call back
      * if manual prop is set to false
@@ -26,7 +26,7 @@ const Button: FC<Overload<Props>> = ({
 
     return (
         <button
-            {...props}
+            {...iButton}
             onClick={buttonOnClick}
             className={`apollo-component-library-modal-component-button-group-button 
                 ${className} ${variant}`}

--- a/src/components/Modal/overload/ButtonGroup.tsx
+++ b/src/components/Modal/overload/ButtonGroup.tsx
@@ -4,20 +4,20 @@ import Overload from '../../../interfaces/Overload';
 import FormatChildren from '../../../util/FormatChildren';
 
 import Button from './Button';
-import { Props } from '../../ButtonGroup/ButtonGroup';
+import { IButtonGroup } from '../../ButtonGroup/ButtonGroup';
 
 /**
  * Overloads ButtonGroup to change style and pass through modal actions
  *
  * @return Formatted ButtonGroup
  */
-const ButtonGroup: FC<Overload<Props>> = ({
+const ButtonGroup: FC<Overload<IButtonGroup>> = ({
     parentProps: { children, ...parentProps },
     className = '',
-    ...props
-}: Overload<Props>) => {
-    // get all props
-    const allProps = { ...props, ...parentProps };
+    ...iButtonGroup
+}: Overload<IButtonGroup>) => {
+    // get all iButtonGroup
+    const allProps = { ...iButtonGroup, ...parentProps };
 
     // find the buttons in the button group
     const formattedButtonGroup = new FormatChildren(allProps, { Button });

--- a/src/components/Modal/overload/Footer.tsx
+++ b/src/components/Modal/overload/Footer.tsx
@@ -10,7 +10,10 @@ import { IFooter, Footer as CFooter } from '../../Footer/Footer';
  *
  * @return formatted footer
  */
-const Footer: FC<IFooter> = ({ parentProps: { children, ...parentProps }, ...iFooter }: IFooter) => {
+const Footer: FC<IFooter> = ({
+    parentProps: { children, ...parentProps },
+    ...iFooter
+}: IFooter) => {
     // gets all iFooter
     const allProps = { ...iFooter, ...parentProps };
 

--- a/src/components/Modal/overload/Footer.tsx
+++ b/src/components/Modal/overload/Footer.tsx
@@ -3,16 +3,16 @@ import React from 'react';
 import FormatChildren from '../../../util/FormatChildren';
 
 import ButtonGroup from './ButtonGroup';
-import { Props, Footer as CFooter } from '../../Footer/Footer';
+import { IFooter, Footer as CFooter } from '../../Footer/Footer';
 
 /**
  * Overloaded Footer that identifies button groups
  *
  * @return formatted footer
  */
-const Footer: FC<Props> = ({ parentProps: { children, ...parentProps }, ...props }: Props) => {
-    // gets all props
-    const allProps = { ...props, ...parentProps };
+const Footer: FC<IFooter> = ({ parentProps: { children, ...parentProps }, ...iFooter }: IFooter) => {
+    // gets all iFooter
+    const allProps = { ...iFooter, ...parentProps };
 
     // find button groups
     const formattedFooter = new FormatChildren(allProps, { ButtonGroup });
@@ -28,7 +28,7 @@ const Footer: FC<Props> = ({ parentProps: { children, ...parentProps }, ...props
     const [buttonGroup] = buttonGroups;
 
     return (
-        <CFooter {...props} parentProps={parentProps} style={footerStyle}>
+        <CFooter {...iFooter} parentProps={parentProps} style={footerStyle}>
             {formattedFooter.getOther()}
             {buttonGroup}
         </CFooter>

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -10,7 +10,7 @@ import './NavigationBar.css';
 import { Text } from '../Text/Text';
 import Section from './overload/Section';
 
-export interface Props extends HTMLAttributes<HTMLDivElement> {
+export interface INavigationBar extends HTMLAttributes<HTMLDivElement> {
     /** If the component is not static, it will determine the orientation of the component */
     orientation?: ComponentVerticalOrientation;
     /** Determines the position of the component */
@@ -30,7 +30,7 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
  *
  * @return Navigation Bar component
  */
-export const NavigationBar: FC<Props> = ({
+export const NavigationBar: FC<INavigationBar> = ({
     size = 'medium',
     position = 'static',
     orientation = 'top',
@@ -38,8 +38,8 @@ export const NavigationBar: FC<Props> = ({
     titleElement,
     onTitleClick,
     style,
-    ...props
-}: Props) => {
+    ...iNavigationBar
+}: INavigationBar) => {
     // refs
     const navigationBar = useRef<HTMLDivElement>(null);
     // state
@@ -67,7 +67,7 @@ export const NavigationBar: FC<Props> = ({
 
     return (
         <div
-            {...props}
+            {...iNavigationBar}
             className={`apollo-component-library-navigation-bar-component 
                 ${position} ${orientation}
             `}

--- a/src/components/NavigationBar/overload/Section.tsx
+++ b/src/components/NavigationBar/overload/Section.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import React, { useEffect, useState } from 'react';
-import { Props, Section as CSection } from '../../Section/Section';
+import { ISection, Section as CSection } from '../../Section/Section';
 
 import FormatChildren from '../../../util/FormatChildren';
 import { Dropdown, Option, Button, Icon } from '../../..';
@@ -11,11 +11,11 @@ import { Dropdown, Option, Button, Icon } from '../../..';
  *
  * @return Formatted section component
  */
-const Section: FC<Props> = ({
+const Section: FC<ISection> = ({
     parentProps: { mobile, titleColor },
     children,
     navigation,
-    ...props
+    ...iSection
 }) => {
     // state
     const [sectionChildren, setSectionChildren] = useState(children);
@@ -43,7 +43,7 @@ const Section: FC<Props> = ({
         }
     }, [mobile]);
 
-    return <CSection {...props}>{sectionChildren}</CSection>;
+    return <CSection {...iSection}>{sectionChildren}</CSection>;
 };
 
 export default Section;

--- a/src/components/Option/Option.tsx
+++ b/src/components/Option/Option.tsx
@@ -6,7 +6,7 @@ import Overload from '../../interfaces/Overload';
 
 import { Text } from '../Text/Text';
 
-export interface Props extends Overload<HTMLAttributes<HTMLElement>> {
+export interface IOption extends Overload<HTMLAttributes<HTMLElement>> {
     /** Needs to have a string value in between tags */
     children: string;
     /** Can have onClick callback method */
@@ -18,9 +18,9 @@ export interface Props extends Overload<HTMLAttributes<HTMLElement>> {
  *
  * @return Option component
  */
-export const Option: FC<Props> = ({ children, parentProps, className = '', ...props }) => {
+export const Option: FC<IOption> = ({ children, parentProps, className = '', ...iOption }) => {
     return (
-        <div {...props} className={`apollo-component-library-option-component ${className}`}>
+        <div {...iOption} className={`apollo-component-library-option-component ${className}`}>
             <Text margins={false}>{children}</Text>
         </div>
     );

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Text } from '../Text/Text';
 import './Radio.css';
 
-export interface Props extends HTMLAttributes<HTMLInputElement> {
+export interface IRadio extends HTMLAttributes<HTMLInputElement> {
     /** String that identifies the radio */
     id?: string;
     /** You can define an element pertaining to radio */
@@ -32,7 +32,7 @@ export interface Props extends HTMLAttributes<HTMLInputElement> {
  *
  * @return Radio component
  */
-export const Radio: FC<Props> = ({
+export const Radio: FC<IRadio> = ({
     inline = false,
     children,
     className,
@@ -40,7 +40,7 @@ export const Radio: FC<Props> = ({
     required,
     errorMessage,
     id,
-    ...props
+    ...iRadio
 }) => {
     // check if the user can use error messages
     useEffect(() => {
@@ -59,7 +59,7 @@ export const Radio: FC<Props> = ({
                 `}
             >
                 <input
-                    {...props}
+                    {...iRadio}
                     aria-required={required}
                     aria-invalid={invalid}
                     aria-errormessage={id ? `${id}-error` : undefined}

--- a/src/components/Section/Section.tsx
+++ b/src/components/Section/Section.tsx
@@ -3,7 +3,7 @@ import React, { CSSProperties } from 'react';
 import Overload from '../../interfaces/Overload';
 import * as CSS from 'csstype';
 
-export interface Props extends Overload<HTMLAttributes<HTMLDivElement>> {
+export interface ISection extends Overload<HTMLAttributes<HTMLDivElement>> {
     /** value that determines the flex style prop of section */
     flex?: CSS.Property.Flex;
     /** value that determines the height of section */
@@ -28,7 +28,7 @@ export interface Props extends Overload<HTMLAttributes<HTMLDivElement>> {
  *
  * @return section component
  */
-export const Section: FC<Props> = ({
+export const Section: FC<ISection> = ({
     parentProps,
     flex = 1,
     children,
@@ -38,11 +38,11 @@ export const Section: FC<Props> = ({
     style,
     justifyContent,
     alignItems,
-    ...props
+    ...iSection
 }) => {
     return (
         <div
-            {...props}
+            {...iSection}
             className={className}
             style={getSectionStyle(flex, height, width, alignItems, justifyContent, style)}
         >

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -4,7 +4,7 @@ import { StyleVariant } from '../../interfaces/Properties';
 import { Text } from '../Text/Text';
 import './Switch.css';
 
-export interface Props extends HTMLAttributes<HTMLInputElement> {
+export interface ISwitch extends HTMLAttributes<HTMLInputElement> {
     /** Can assign text or element to switch */
     children: ReactNode;
     /** Determines whether the switch is disabled */
@@ -26,19 +26,19 @@ export interface Props extends HTMLAttributes<HTMLInputElement> {
  *
  * @return Switch component
  */
-export const Switch: FC<Props> = ({
+export const Switch: FC<ISwitch> = ({
     variant = 'default',
     className = '',
     children,
     required,
     name,
-    ...props
+    ...iSwitch
 }) => {
     return (
         <div className="apollo-component-library-switch-component-wrapper">
             <label className="apollo-component-library-switch-component-label">
                 <input
-                    {...props}
+                    {...iSwitch}
                     type="checkbox"
                     role="switch"
                     className="apollo-component-library-switch-component-input"

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode } from 'react';
 import * as CSS from 'csstype';
 import './Text.css';
 
-export interface Props extends HTMLAttributes<HTMLParagraphElement> {
+export interface IText extends HTMLAttributes<HTMLParagraphElement> {
     /** Text needs to exist between tags */
     children: ReactNode;
     /**
@@ -27,7 +27,7 @@ export interface Props extends HTMLAttributes<HTMLParagraphElement> {
     lower?: boolean;
     /** Determines whether the first letter of every word is capital or not */
     pascal?: boolean;
-    /** Decide the color of the text without accessing the style props */
+    /** Decide the color of the text without accessing the style iText */
     color?: CSS.Property.Color;
     /** Determines whether the text is disabled or not */
     disabled?: boolean;
@@ -38,7 +38,7 @@ export interface Props extends HTMLAttributes<HTMLParagraphElement> {
  *
  * @return Text component
  */
-export const Text: FC<Props> = ({
+export const Text: FC<IText> = ({
     children,
     className = '',
     header = 0,
@@ -53,7 +53,7 @@ export const Text: FC<Props> = ({
     disabled = false,
     color,
     style,
-    ...props
+    ...iText
 }) => {
     /**
      * Gets all the special conditions and translates it to a special className combination
@@ -121,7 +121,7 @@ export const Text: FC<Props> = ({
     };
 
     return (
-        <span {...props} style={getTextStyle(color, style)} className={getVariant()}>
+        <span {...iText} style={getTextStyle(color, style)} className={getVariant()}>
             {getCorrectCasing()}
         </span>
     );

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -6,7 +6,7 @@ import './TextInput.css';
 
 import { Text } from '../Text/Text';
 
-export interface Props extends HTMLAttributes<HTMLInputElement> {
+export interface ITextInput extends HTMLAttributes<HTMLInputElement> {
     /** To comply with WCAG 2.0, all inputs **must** have labels */
     label: string;
     /** Gives further description on what the input should have to be valid */
@@ -36,7 +36,7 @@ export interface Props extends HTMLAttributes<HTMLInputElement> {
  *
  * @return TextInput component
  */
-export const TextInput: FC<Props> = ({
+export const TextInput: FC<ITextInput> = ({
     variant = 'default',
     className = '',
     password = false,
@@ -47,7 +47,7 @@ export const TextInput: FC<Props> = ({
     id,
     hint,
     label,
-    ...props
+    ...iTextInput
 }) => {
     // will throw if you try to add an error message without a name
     useEffect(() => {
@@ -71,7 +71,7 @@ export const TextInput: FC<Props> = ({
                 </Text>
                 {hint?.length ? <Text style={hintTextStyle}>{hint}</Text> : null}
                 <input
-                    {...props}
+                    {...iTextInput}
                     aria-required={required}
                     aria-invalid={invalid}
                     aria-errormessage={name ? `${name}-error` : undefined}

--- a/src/components/View/View.tsx
+++ b/src/components/View/View.tsx
@@ -1,7 +1,7 @@
 import type { HTMLAttributes, ReactNode, FC } from 'react';
 import React from 'react';
 
-interface Props extends HTMLAttributes<HTMLDivElement> {
+interface IView extends HTMLAttributes<HTMLDivElement> {
     /** May have children */
     children?: ReactNode;
 }
@@ -11,6 +11,6 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
  *
  * @return View component
  */
-export const View: FC<Props> = ({ children, ...props }) => {
-    return <div {...props}>{children}</div>;
+export const View: FC<IView> = ({ children, ...iView }) => {
+    return <div {...iView}>{children}</div>;
 };

--- a/stories/Alert.stories.tsx
+++ b/stories/Alert.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react';
-import { Alert, Props } from '../src/components/Alert/Alert';
+import { Alert, IALert } from '../src/components/Alert/Alert';
 import { Text } from '../src';
 
 const meta: Meta = {
@@ -19,7 +19,7 @@ export default meta;
  * @param args storybook arguments
  * @return template Alert component
  */
-export const AlertTypes: Story<Props> = (args): JSX.Element => (
+export const AlertTypes: Story<IALert> = (args): JSX.Element => (
     <React.Fragment>
         <Alert {...args}>
             <Text bold>{args.children}</Text>

--- a/stories/Button.stories.tsx
+++ b/stories/Button.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Meta, Story } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
-import { Button, Props } from '../src/components/Button/Button';
+import { Button, IButton } from '../src/components/Button/Button';
 
 const meta: Meta = {
     title: 'Layout/Button',
@@ -21,7 +21,7 @@ export default meta;
  * @param args story args
  * @return template button
  */
-const Template: Story<Props> = (args) => <Button {...args} />;
+const Template: Story<IButton> = (args) => <Button {...args} />;
 
 export const Default = Template.bind({});
 export const Secondary = Template.bind({});

--- a/stories/ButtonGroup.stories.tsx
+++ b/stories/ButtonGroup.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Story, Meta } from '@storybook/react';
 
-import { ButtonGroup, Props } from '../src/components/ButtonGroup/ButtonGroup';
+import { ButtonGroup, IButtonGroup } from '../src/components/ButtonGroup/ButtonGroup';
 import { Button, Switch } from '../src';
 
 const meta: Meta = {
@@ -17,7 +17,7 @@ export default meta;
  * @param args storybook arguments
  * @return template component
  */
-const Template: Story<Props> = (args) => {
+const Template: Story<IButtonGroup> = (args) => {
     const [checked, setChecked] = useState(false);
     return (
         <>

--- a/stories/CSForm.stories.tsx
+++ b/stories/CSForm.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
 
-import { Form, Props } from '../src/components/Form/Form';
+import { Form, IForm } from '../src/components/Form/Form';
 import { TextInput, Button, Group, Radio, Checkbox, Switch } from '../src';
 import { FormValidator } from '../src/interfaces/Properties';
 
@@ -27,7 +27,7 @@ const passwordValidator: FormValidator = (data) =>
  * @param args storybook arguments
  * @return storybook template
  */
-const TextInputFormTemplate: Story<Props> = (args) => {
+const TextInputFormTemplate: Story<IForm> = (args) => {
     return (
         <Form
             onError={(data) => console.log(data)}
@@ -58,7 +58,7 @@ export const TextInputForm = TextInputFormTemplate.bind({});
  * @param args storybook arguments
  * @return storybook template
  */
-const RadioGroupFormTemplate: Story<Props> = (args) => {
+const RadioGroupFormTemplate: Story<IForm> = (args) => {
     return (
         <Form
             onSubmit={(data) => window.alert(data.rating.radio)}
@@ -84,7 +84,7 @@ export const RadioGroupForm = RadioGroupFormTemplate.bind({});
  * @param args storybook arguments
  * @return storybook template
  */
-const CheckboxGroupFormTemplate: Story<Props> = (args) => {
+const CheckboxGroupFormTemplate: Story<IForm> = (args) => {
     return (
         <Form
             onSubmit={(data) => window.alert(data.rating.checkbox)}
@@ -110,7 +110,7 @@ export const CheckboxGroupForm = CheckboxGroupFormTemplate.bind({});
  * @param args storybook arguments
  * @return storybook template
  */
-const IndividualInputFormTemplate: Story<Props> = (args) => {
+const IndividualInputFormTemplate: Story<IForm> = (args) => {
     return (
         <Form
             onSubmit={(data) => window.alert(data.rating.checkbox)}

--- a/stories/Card.stories.tsx
+++ b/stories/Card.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react';
 
-import { Card, Props } from '../src/components/Card/Card';
+import { Card, ICard } from '../src/components/Card/Card';
 import { Header, Footer, Text } from '../src';
 
 const meta: Meta = {
@@ -20,7 +20,7 @@ export default meta;
  * @param args storybook arguments
  * @return template card
  */
-const Template: Story<Props> = (args) => <Card {...args} />;
+const Template: Story<ICard> = (args) => <Card {...args} />;
 
 export const Default = Template.bind({});
 

--- a/stories/Checkbox.stories.tsx
+++ b/stories/Checkbox.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react';
-import { Checkbox, Props } from '../src/components/Checkbox/Checkbox';
+import { Checkbox, ICheckbox } from '../src/components/Checkbox/Checkbox';
 
 const meta: Meta = {
     title: 'Form/Checkbox',
@@ -20,6 +20,6 @@ export default meta;
  * @param args storybook arguments
  * @return Template checkbox
  */
-const Template: Story<Props> = (args) => <Checkbox {...args} />;
+const Template: Story<ICheckbox> = (args) => <Checkbox {...args} />;
 
 export const Default = Template.bind({});

--- a/stories/DateTimePicker.stories.tsx
+++ b/stories/DateTimePicker.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
 
-import { DateTimePicker, Props } from '../src/components/DateTimePicker/DateTimePicker';
+import { DateTimePicker, IDateTimePicker } from '../src/components/DateTimePicker/DateTimePicker';
 
 const meta: Meta = {
     title: 'Layout/DateTimePicker',
@@ -16,6 +16,6 @@ export default meta;
  * @param args storybook args
  * @return template datetimepicker
  */
-const Template: Story<Props> = (args) => <DateTimePicker {...args} />;
+const Template: Story<IDateTimePicker> = (args) => <DateTimePicker {...args} />;
 
 export const Default = Template.bind({});

--- a/stories/Divider.stories.tsx
+++ b/stories/Divider.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
 
-import { Props, Divider } from '../src/components/Divider/Divider';
+import { IDivider, Divider } from '../src/components/Divider/Divider';
 
 const meta: Meta = {
     title: 'Layout/Divider',
@@ -20,6 +20,6 @@ export default meta;
  * @param args storybook args
  * @return template divider
  */
-const Template: Story<Props> = (args) => <Divider {...args} />;
+const Template: Story<IDivider> = (args) => <Divider {...args} />;
 
 export const Default = Template.bind({});

--- a/stories/Drawer.stories.tsx
+++ b/stories/Drawer.stories.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Story, Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
-import { Drawer, Props } from '../src/components/Drawer/Drawer';
+import { Drawer, IDrawer } from '../src/components/Drawer/Drawer';
 import { Header, Footer, Option, Text, Divider, Button } from '../src';
 
 const meta: Meta = {
@@ -21,7 +21,7 @@ export default meta;
  * @param args storybook arguments
  * @return template drawer
  */
-const Template: Story<Props> = (args) => {
+const Template: Story<IDrawer> = (args) => {
     const [open, toggleOpen] = useState(false);
 
     return (
@@ -53,7 +53,7 @@ const Template: Story<Props> = (args) => {
  * @param args storybook arguments
  * @return template persistent drawer
  */
-const PersistentTemplate: Story<Props> = (args) => {
+const PersistentTemplate: Story<IDrawer> = (args) => {
     const [open, toggleOpen] = useState(false);
 
     return (
@@ -269,7 +269,7 @@ const PersistentTemplate: Story<Props> = (args) => {
  * @param args storybook arguments
  * @return template pernmanent drawer
  */
-const PermanentTemplate: Story<Props> = (args) => {
+const PermanentTemplate: Story<IDrawer> = (args) => {
     const [open, toggleOpen] = useState(false);
 
     return (

--- a/stories/Dropdown.stories.tsx
+++ b/stories/Dropdown.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
 
-import { Dropdown, Props } from '../src/components/Dropdown/Dropdown';
+import { Dropdown, IDropdown } from '../src/components/Dropdown/Dropdown';
 import { Option } from '../src/components/Option/Option';
 import { Button } from '../src/components/Button/Button';
 import { Text } from '../src/components/Text/Text';
@@ -23,7 +23,7 @@ export default meta;
  * @param args storybook arguments
  * @return template dropdown
  */
-export const Default: Story<Props> = (args) => (
+export const Default: Story<IDropdown> = (args) => (
     <Dropdown {...args}>
         <Button>
             <Text inline>This is a dropdown</Text>
@@ -39,7 +39,7 @@ export const Default: Story<Props> = (args) => (
  * @param args storybook arguments
  * @return template button dropdown
  */
-export const AnotherExample: Story<Props> = (args) => (
+export const AnotherExample: Story<IDropdown> = (args) => (
     <Dropdown {...args}>
         <Button>
             <Button>Whats good</Button>

--- a/stories/Footer.stories.tsx
+++ b/stories/Footer.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
 
-import { Footer, Props } from '../src/components/Footer/Footer';
+import { Footer, IFooter } from '../src/components/Footer/Footer';
 
 const meta: Meta = {
     title: 'Interfacing/Footer',
@@ -19,6 +19,6 @@ export default meta;
  * @param args storybook arguments
  * @return template footer component
  */
-const Template: Story<Props> = (args) => <Footer {...args} />;
+const Template: Story<IFooter> = (args) => <Footer {...args} />;
 
 export const Default = Template.bind({});

--- a/stories/Group.stories.tsx
+++ b/stories/Group.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react';
 
-import { Props, Group } from '../src/components/Group/Group';
+import { IGroup, Group } from '../src/components/Group/Group';
 import { Radio, Checkbox, View, TextInput } from '../src';
 
 const meta: Meta = {
@@ -26,7 +26,7 @@ const onChange = (groupValue: string | string[]): void => {
  * @param args arguments
  * @return radio group
  */
-const RadioTemplate: Story<Props> = (args): JSX.Element => (
+const RadioTemplate: Story<IGroup> = (args): JSX.Element => (
     <Group {...args} name="something">
         <Radio value="something 1">Option 1</Radio>
         <Radio value="something 2">Option 2</Radio>
@@ -40,7 +40,7 @@ const RadioTemplate: Story<Props> = (args): JSX.Element => (
  * @param args arguments
  * @return radio group
  */
-const CheckboxTemplate: Story<Props> = (args): JSX.Element => (
+const CheckboxTemplate: Story<IGroup> = (args): JSX.Element => (
     <Group {...args} name="something">
         <Checkbox value="something 1">Option 1</Checkbox>
         <Checkbox value="something 2">Option 2</Checkbox>

--- a/stories/Header.stories.tsx
+++ b/stories/Header.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
 
-import { Header, Props } from '../src/components/Header/Header';
+import { Header, IHeader } from '../src/components/Header/Header';
 
 const meta: Meta = {
     title: 'Interfacing/Header',
@@ -19,6 +19,6 @@ export default meta;
  * @param args storybook arguments
  * @return template header
  */
-const Template: Story<Props> = (args) => <Header {...args} />;
+const Template: Story<IHeader> = (args) => <Header {...args} />;
 
 export const Default = Template.bind({});

--- a/stories/Icon.stories.tsx
+++ b/stories/Icon.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react';
 
-import { Icon, Props } from '../src/components/Icon/Icon';
+import { Icon, IIcon } from '../src/components/Icon/Icon';
 
 const meta: Meta = {
     title: 'Layout/Icon',
@@ -20,6 +20,6 @@ export default meta;
  * @param args storybook arguments
  * @return template icon
  */
-const Template: Story<Props> = (args) => <Icon {...args} />;
+const Template: Story<IIcon> = (args) => <Icon {...args} />;
 
 export const Default = Template.bind({});

--- a/stories/LoadingState.stories.tsx
+++ b/stories/LoadingState.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Story, Meta } from '@storybook/react';
-import { LoadingState, Props } from '../src/components/LoadingState/LoadingState';
+import { LoadingState, ILoadingState } from '../src/components/LoadingState/LoadingState';
 import { Button, Text } from '../src';
 
 const meta: Meta = {
@@ -19,7 +19,7 @@ export default meta;
  * @param args storybook arguments
  * @return template LoadingState component
  */
-const Template: Story<Props> = (args) => {
+const Template: Story<ILoadingState> = (args) => {
     const [open, isLoading] = useState(false);
     const buttonText = `${args.type} loading shown here`;
 

--- a/stories/Modal.stories.tsx
+++ b/stories/Modal.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Story, Meta } from '@storybook/react';
 
-import { Modal, Props } from '../src/components/Modal/Modal';
+import { Modal, IModal } from '../src/components/Modal/Modal';
 import { Button, Text, Header, Footer, ButtonGroup } from '../src';
 
 const meta: Meta = {
@@ -17,7 +17,7 @@ export default meta;
  * @param args storybook arguments
  * @return template modal component
  */
-const Template: Story<Props> = (args) => {
+const Template: Story<IModal> = (args) => {
     const [open, toggleModal] = useState(false);
 
     return (

--- a/stories/NavigationBar.stories.tsx
+++ b/stories/NavigationBar.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { NavigationBar, Props } from '../src/components/NavigationBar/NavigationBar';
+import { NavigationBar, INavigationBar } from '../src/components/NavigationBar/NavigationBar';
 import { Story, Meta } from '@storybook/react';
 import { Section, Text, Dropdown, Button, Icon, Option } from '../src';
 
@@ -16,7 +16,7 @@ export default meta;
  * @param args arguments for navigation bar
  * @return template of Navigation bar
  */
-const Template: Story<Props> = (args) => (
+const Template: Story<INavigationBar> = (args) => (
     <div
         style={{
             position: 'relative',
@@ -83,7 +83,7 @@ const printMessage = (): JSX.Element[] => {
  * @param args arguments for navigation bar
  * @return template of Navigation bar
  */
-const FixedTemplate: Story<Props> = (args) => (
+const FixedTemplate: Story<INavigationBar> = (args) => (
     <div
         style={{
             position: 'relative',

--- a/stories/Option.stories.tsx
+++ b/stories/Option.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
 
-import { Option, Props } from '../src/components/Option/Option';
+import { Option, IOption } from '../src/components/Option/Option';
 
 const meta: Meta = {
     title: 'Interfacing/Option',
@@ -19,6 +19,6 @@ export default meta;
  * @param args storybook arguments
  * @return Template Option
  */
-const Template: Story<Props> = (args) => <Option {...args} />;
+const Template: Story<IOption> = (args) => <Option {...args} />;
 
 export const Default = Template.bind({});

--- a/stories/Radio.stories.tsx
+++ b/stories/Radio.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react';
-import { Props, Radio } from '../src/components/Radio/Radio';
+import { IRadio, Radio } from '../src/components/Radio/Radio';
 
 const meta: Meta = {
     title: 'Form/Radio',
@@ -20,6 +20,6 @@ export default meta;
  * @param args storybook arguments
  * @return template radio component
  */
-const Template: Story<Props> = (args) => <Radio {...args} />;
+const Template: Story<IRadio> = (args) => <Radio {...args} />;
 
 export const Default = Template.bind({});

--- a/stories/SSForm.stories.tsx
+++ b/stories/SSForm.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Story, Meta } from '@storybook/react';
 
-import type { Props } from '../src/components/Form/Form';
+import type { IForm } from '../src/components/Form/Form';
 import { Form, TextInput, Button, Group, Radio, Checkbox, Switch } from '../src';
 import { FormActionData } from '../src/interfaces/Properties';
 
@@ -34,7 +34,7 @@ const validActionData: FormActionData = {
  * @param args storybook arguments
  * @return text input form template
  */
-const TextInputFormTepmlate: Story<Props> = (args) => (
+const TextInputFormTepmlate: Story<IForm> = (args) => (
     <Form {...args}>
         <TextInput label="Username" name="username" />
         <TextInput label="Password" name="password" password />
@@ -53,7 +53,7 @@ TextInputForm.args = {
  * @param args storybook arguments
  * @return storybook template
  */
-const RadioGroupFormTemplate: Story<Props> = (args) => {
+const RadioGroupFormTemplate: Story<IForm> = (args) => {
     return (
         <Form {...args}>
             <Group required label="Please rate the class from 1-5" name="rating" inline>
@@ -79,7 +79,7 @@ RadioGroupForm.args = {
  * @param args storybook arguments
  * @return storybook template
  */
-const CheckboxGroupFormTemplate: Story<Props> = (args) => {
+const CheckboxGroupFormTemplate: Story<IForm> = (args) => {
     return (
         <Form {...args}>
             <Group required label="Select options" name="options">
@@ -105,7 +105,7 @@ CheckboxGroupForm.args = {
  * @param args storybook arguments
  * @return storybook template
  */
-const IndividualInputFormTemplate: Story<Props> = (args) => {
+const IndividualInputFormTemplate: Story<IForm> = (args) => {
     return (
         <Form {...args}>
             <Radio required id="radio" value="radio">

--- a/stories/Section.stories.tsx
+++ b/stories/Section.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Section, Props } from '../src/components/Section/Section';
+import { Section, ISection } from '../src/components/Section/Section';
 import { Meta, Story } from '@storybook/react';
 
 const meta: Meta = {
@@ -23,7 +23,7 @@ export default meta;
  * @param args arguments for section
  * @return template
  */
-const Template: Story<Props> = (args) => (
+const Template: Story<ISection> = (args) => (
     <div style={{ display: 'flex', height: 300, width: 500 }}>
         <Section {...args} style={{ background: 'red' }}>
             1

--- a/stories/Switch.stories.tsx
+++ b/stories/Switch.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react';
-import { Switch, Props } from '../src/components/Switch/Switch';
+import { Switch, ISwitch } from '../src/components/Switch/Switch';
 
 const meta: Meta = {
     title: 'Form/Switch',
@@ -18,7 +18,7 @@ export default meta;
  * @param args storybook arguments
  * @return template switch
  */
-const Template: Story<Props> = (args) => <Switch {...args} />;
+const Template: Story<ISwitch> = (args) => <Switch {...args} />;
 
 export const Default = Template.bind({});
 

--- a/stories/Text.stories.tsx
+++ b/stories/Text.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react';
-import { Text, Props } from '../src/components/Text/Text';
+import { Text, IText } from '../src/components/Text/Text';
 
 const meta: Meta = {
     title: 'Layout/Text',
@@ -18,7 +18,7 @@ export default meta;
  * @param args storybook arguments
  * @return template text
  */
-const Template: Story<Props> = (args) => <Text {...args} />;
+const Template: Story<IText> = (args) => <Text {...args} />;
 
 export const Default = Template.bind({});
 

--- a/stories/TextInput.stories.tsx
+++ b/stories/TextInput.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react';
-import { TextInput, Props } from '../src/components/TextInput/TextInput';
+import { TextInput, ITextInput } from '../src/components/TextInput/TextInput';
 
 const meta: Meta = {
     title: 'Form/Text Input',
@@ -18,6 +18,6 @@ export default meta;
  * @param args storybook arguments
  * @return template text input
  */
-const Template: Story<Props> = (args) => <TextInput {...args} />;
+const Template: Story<ITextInput> = (args) => <TextInput {...args} />;
 
 export const Default = Template.bind({});


### PR DESCRIPTION
The Chore:
All the current components props have the name: Props, we want to change that to a different name for each component to separate concern.

Purpose:
When we are finally going to be used in production the on hover captions may confuse the user into thinking that we have a universal Props interface that represents all components. This may lead to usage confusion and may be counter-intuitive for a purposes.

The Method:
Changed Props to resemble component name Example=> IButton
Changed props to resemble component name Example=> iButton