### PR TITLE
component: modified Button to be accessible

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -11,8 +11,6 @@ export interface IButton extends HTMLAttributes<HTMLButtonElement> {
     variant?: StyleVariant;
     /** callback function to be called when there is a method click */
     onClick?: () => void;
-    /** will allow for http redirect */
-    href?: string;
     /** Allows use of references */
     ref?: ForwardedRef<HTMLButtonElement>;
 }
@@ -23,21 +21,12 @@ export interface IButton extends HTMLAttributes<HTMLButtonElement> {
  * @return Button component
  */
 export const Button: FC<IButton> = forwardRef(function Button(
-    { children, onClick, href, className = '', variant = 'default', ...props }: IButton,
+    { children, className = '', variant = 'default', ...props }: IButton,
     ref: ForwardedRef<HTMLButtonElement>
 ) {
-    /** Handles click open link if href > 0 */
-    const handleClick = (): void => {
-        if (onClick) onClick();
-        if (href && href.length > 0) {
-            window.open(href, '_blank');
-        }
-    };
-
     return (
         <button
             {...props}
-            onClick={handleClick}
             className={`apollo-component-library-button ${variant} ${className}`}
             ref={ref}
         >

--- a/test/Button.test.tsx
+++ b/test/Button.test.tsx
@@ -24,16 +24,4 @@ describe('Button', () => {
         // then
         expect(onClick).toHaveBeenCalledTimes(1);
     });
-
-    it('can open a link', () => {
-        // given
-        global.open = jest.fn();
-        render(<Button href="https://google.com">Click me</Button>);
-
-        // when
-        userEvent.click(screen.getByRole('button', { name: /click me/i }));
-
-        // then
-        expect(global.open).toBeCalled();
-    });
 });


### PR DESCRIPTION
# component: modified Button to be accessible
Removed link capabilities from Button component with the `handleCLick` method and `href` prop.
Also removed the test related to the same functionality.
- [ahmedpythondev/mil-600-chore-remove-link-capabilities-from](https://linear.app/milemarker10/issue/MIL-600/chore-remove-link-capabilities-from-buttons)

## Purpose
To make the Button Component accessible to screen-reader users it was important to make sure it fully compatible with WCAG 2.0.

## Summary of Changes
In this PR i removed the `href` prop, `handleClick` method and their respective tests from Button Component

# Certificate
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.