### PR TITLE
component: added area variant in Button component

### DIFF
--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -24,3 +24,9 @@
 .apollo-component-library-button.secondary {
     background: #57aeff;
 }
+
+.apollo-component-library-button.area {
+    background: none;
+    border: none;
+    padding: 0px;
+}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -8,7 +8,7 @@ export interface IButton extends HTMLAttributes<HTMLButtonElement> {
     /** Required ReactNode that needs to exist between component tags */
     children: ReactNode;
     /** defines the type of button to be rendered */
-    variant?: StyleVariant;
+    variant?: StyleVariant | 'area';
     /** callback function to be called when there is a method click */
     onClick?: () => void;
     /** Allows use of references */

--- a/stories/Button.stories.mdx
+++ b/stories/Button.stories.mdx
@@ -37,6 +37,8 @@ difference.
                 <Button>Default</Button>
                 <span style={{ paddingRight: 10 }} />
                 <Button variant="secondary">Secondary</Button>
+                <span style={{ paddingRight: 10 }} />
+                <Button variant="area">Area</Button>
             </>
         )}
     </Story>


### PR DESCRIPTION
# component: added area variant in Button component
In this PR we added a new Area variant in the Button component. This varrient functions like a Button
without the style of a Button.
- [feature/ahmedpythondev/mil-569-add-area-variant-to-button](https://linear.app/milemarker10/issue/MIL-569/add-area-variant-to-button)

## Purpose
In this PR we add Area variant to the Button Component, the reason behind this is to have a clickable area which acts exactly like a button without the styling of a Button.

## Summary of Changes
This PR has the following changes
- added  variant in `Button.tsx`
- added `background:none` for  variant in `Button.css`
- defined `area` variant in `Button.stories.mdx`

# Certificate
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.