### PR TITLE
Changed Apollo's Identification method for Format Children

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.0.6",
+    "version": "0.0.8",
     "license": "MIT",
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -2,7 +2,10 @@ import type { HTMLAttributes, ReactNode, FC } from 'react';
 import React from 'react';
 import './Alert.css';
 
-export interface IAlert extends HTMLAttributes<HTMLParagraphElement> {
+import type { Apollo } from '../../interfaces/Apollo';
+import { gaurdApolloName } from '../../util/ErrorHandling';
+
+export interface IAlert extends HTMLAttributes<HTMLParagraphElement>, Apollo<'Alert'> {
     /** Alert needs to exist between tags */
     children: ReactNode;
     /**
@@ -10,7 +13,6 @@ export interface IAlert extends HTMLAttributes<HTMLParagraphElement> {
      * tag i.e. type=warning => warning
      */
     type?: 'danger' | 'warning' | 'info' | 'success';
-    /** Determines whether the element has margins or not */
 }
 
 /**
@@ -18,12 +20,9 @@ export interface IAlert extends HTMLAttributes<HTMLParagraphElement> {
  *
  * @return Alert component
  */
-export const Alert: FC<IAlert> = ({
-    children,
-    type = 'danger',
+export const Alert: FC<IAlert> = ({ children, type = 'danger', ...props }) => {
+    gaurdApolloName(props, 'Alert');
 
-    ...props
-}) => {
     /**
      * Gets all the special conditions and translates it to a special className combination
      * granting all conditions
@@ -49,3 +48,5 @@ export const Alert: FC<IAlert> = ({
         </div>
     );
 };
+
+Alert.defaultProps = { 'data-apollo': 'Alert' };

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,10 +1,13 @@
 /* eslint-disable react/prop-types */
 import type { HTMLAttributes, ReactNode, FC, ForwardedRef } from 'react';
 import React, { forwardRef } from 'react';
-import type { StyleVariant } from '../../interfaces/Properties';
 import './Button.css';
 
-export interface IButton extends HTMLAttributes<HTMLButtonElement> {
+import type { Apollo } from '../../interfaces/Apollo';
+import type { StyleVariant } from '../../interfaces/Properties';
+import { gaurdApolloName } from '../../util/ErrorHandling';
+
+export interface IButton extends HTMLAttributes<HTMLButtonElement>, Apollo<'Button'> {
     /** Required ReactNode that needs to exist between component tags */
     children: ReactNode;
     /** defines the type of button to be rendered */
@@ -24,6 +27,8 @@ export const Button: FC<IButton> = forwardRef(function Button(
     { children, className = '', variant = 'default', ...props }: IButton,
     ref: ForwardedRef<HTMLButtonElement>
 ) {
+    gaurdApolloName(props, 'Button');
+
     return (
         <button
             {...props}
@@ -34,3 +39,5 @@ export const Button: FC<IButton> = forwardRef(function Button(
         </button>
     );
 });
+
+Button.defaultProps = { 'data-apollo': 'Button' };

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import './ButtonGroup.css';
 
 import FormatChildren from '../../util/FormatChildren';
+import type { Apollo } from '../../interfaces/Apollo';
 import type { StyleVariant, ComponentSize } from '../../interfaces/Properties';
+import { gaurdApolloName } from '../../util/ErrorHandling';
 
 import Button from './overload/Button';
 
-export interface IButtonGroup extends HTMLAttributes<HTMLDivElement> {
+export interface IButtonGroup extends HTMLAttributes<HTMLDivElement>, Apollo<'ButtonGroup'> {
     /** Disables all buttons within button group */
     disabled?: boolean;
     /** toggle between different button group sizes */
@@ -31,6 +33,7 @@ export const ButtonGroup: FC<IButtonGroup> = ({
     className,
     ...props
 }) => {
+    gaurdApolloName(props, 'ButtonGroup');
     /**
      * Renders all button group buttons and caches chlidren
      *
@@ -51,3 +54,5 @@ export const ButtonGroup: FC<IButtonGroup> = ({
         </div>
     );
 };
+
+ButtonGroup.defaultProps = { 'data-apollo': 'ButtonGroup' };

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,12 +1,15 @@
 import type { HTMLAttributes, ReactNode, FC } from 'react';
 import React from 'react';
-import FormatChildren from '../../util/FormatChildren';
 import './Card.css';
+
+import type { Apollo } from '../../interfaces/Apollo';
+import FormatChildren from '../../util/FormatChildren';
+import { gaurdApolloName } from '../../util/ErrorHandling';
 
 import { Header } from '../Header/Header';
 import { Footer } from '../Footer/Footer';
 
-export interface ICard extends HTMLAttributes<HTMLDivElement> {
+export interface ICard extends HTMLAttributes<HTMLDivElement>, Apollo<'Card'> {
     /** Accepts any kind of children */
     children?: ReactNode;
 }
@@ -18,6 +21,8 @@ export interface ICard extends HTMLAttributes<HTMLDivElement> {
  * @return Card component
  */
 export const Card: FC<ICard> = ({ children, className, ...props }) => {
+    gaurdApolloName(props, 'Card');
+
     /**
      * Renderes all components
      *
@@ -28,8 +33,8 @@ export const Card: FC<ICard> = ({ children, className, ...props }) => {
         const formatted = new FormatChildren({ children }, { Header, Footer });
 
         // extract header and footer
-        const headers = formatted.get(Header);
-        const footers = formatted.get(Footer);
+        const headers = formatted.get('Header');
+        const footers = formatted.get('Footer');
 
         // check to see that we have one footer and one header MAX
         if (headers.length > 1) throw new Error('Card cannot have more than one header.');
@@ -57,3 +62,5 @@ export const Card: FC<ICard> = ({ children, className, ...props }) => {
         </div>
     );
 };
+
+Card.defaultProps = { 'data-apollo': 'Card' };

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,9 +1,13 @@
 import { HTMLAttributes, ReactNode, FC, CSSProperties, useEffect } from 'react';
 import React from 'react';
-import { Text } from '../Text/Text';
 import './Checkbox.css';
 
-export interface ICheckbox extends HTMLAttributes<HTMLInputElement> {
+import type { Apollo } from '../../interfaces/Apollo';
+import { gaurdApolloName } from '../../util/ErrorHandling';
+
+import { Text } from '../Text/Text';
+
+export interface ICheckbox extends HTMLAttributes<HTMLInputElement>, Apollo<'Checkbox'> {
     /** String that identifies the checkbox */
     id?: string;
     /**  Can have children between tags */
@@ -42,6 +46,8 @@ export const Checkbox: FC<ICheckbox> = ({
     errorMessage,
     ...props
 }) => {
+    gaurdApolloName(props, 'Checkbox');
+
     // check if the user can use error messages
     useEffect(() => {
         if (errorMessage?.length && !id?.length)
@@ -92,6 +98,8 @@ export const Checkbox: FC<ICheckbox> = ({
         </>
     );
 };
+
+Checkbox.defaultProps = { 'data-apollo': 'Checkbox' };
 
 const errorTextStyle: CSSProperties = {
     paddingTop: 5,

--- a/src/components/DateTimePicker/DateTimePicker.tsx
+++ b/src/components/DateTimePicker/DateTimePicker.tsx
@@ -1,12 +1,14 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import type { FC } from 'react';
 import React, { useState } from 'react';
+import './DateTimePicker.css';
+
+import type { Apollo } from '../../interfaces/Apollo';
+import { gaurdApolloName } from '../../util/ErrorHandling';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 
-import './DateTimePicker.css';
-
-export interface IDateTimePicker {
+export interface IDateTimePicker extends Apollo<'DateTimePicker'> {
     /**
      * Determines format of date to be displayed
      * tag i.e. format=dd/MM/yyyy => 24/12/2020
@@ -32,7 +34,10 @@ export const DateTimePicker: FC<IDateTimePicker> = ({
     placeholder = 'Click to add a date',
     selectedDate = new Date(),
     onChange,
+    ...props
 }) => {
+    gaurdApolloName(props, 'DateTimePicker');
+
     const [startDate, setStartDate] = useState<Date | null>(selectedDate);
     // eslint-disable-next-line require-jsdoc
     const newOnChange = (selectedDate: React.SetStateAction<Date | null>) => {
@@ -53,3 +58,5 @@ export const DateTimePicker: FC<IDateTimePicker> = ({
         />
     );
 };
+
+DateTimePicker.defaultProps = { 'data-apollo': 'DateTimePicker' };

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -1,9 +1,12 @@
 import type { HTMLAttributes, FC } from 'react';
 import React from 'react';
-import * as CSS from 'csstype';
 import './Divider.css';
 
-export interface IDivider extends HTMLAttributes<HTMLHRElement> {
+import type { Apollo } from '../../interfaces/Apollo';
+import type * as CSS from 'csstype';
+import { gaurdApolloName } from '../../util/ErrorHandling';
+
+export interface IDivider extends HTMLAttributes<HTMLHRElement>, Apollo<'Divider'> {
     /** color of desired divider */
     color?: CSS.Property.Color;
     /** height of divider in pixels */
@@ -16,6 +19,8 @@ export interface IDivider extends HTMLAttributes<HTMLHRElement> {
  * @return Divider component
  */
 export const Divider: FC<IDivider> = ({ color, className = '', height, style, ...props }) => {
+    gaurdApolloName(props, 'Divider');
+
     return (
         <hr
             role="separator"
@@ -25,6 +30,8 @@ export const Divider: FC<IDivider> = ({ color, className = '', height, style, ..
         />
     );
 };
+
+Divider.defaultProps = { 'data-apollo': 'Divider' };
 
 /**
  * Gets the style object for the divider

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -3,16 +3,16 @@ import React, { useEffect, useState, useRef } from 'react';
 import FormatChildren from '../../util/FormatChildren';
 import './Drawer.css';
 
+import type { Apollo } from '../../interfaces/Apollo';
 import type { ComponentOrientation, ComponentRenderAll } from '../../interfaces/Properties';
+import { gaurdApolloName } from '../../util/ErrorHandling';
 
 import { View } from '../View/View';
-
 import Menu from './overload/Menu';
+import type { IDrawerButton } from './overload/Button';
 import Button from './overload/Button';
-import { IButton } from '../Button/Button';
-import Overload from '../../interfaces/Overload';
 
-export interface IDrawer extends HTMLAttributes<HTMLDivElement> {
+export interface IDrawer extends HTMLAttributes<HTMLDivElement>, Apollo<'Drawer'> {
     /**
      * Type of drawer that will be used. `absolute` assumes the drawer is in front of everything
      * and will use a backdrop. `persistent` will have a relative width and can push other
@@ -45,7 +45,7 @@ export interface IDrawer extends HTMLAttributes<HTMLDivElement> {
  *
  * @return Drawer Component
  */
-export const Drawer: FC<IDrawer> & { Button: FC<Overload<IButton>> } = ({
+export const Drawer: FC<IDrawer> & { Button: FC<IDrawerButton> } = ({
     children,
     className = '',
     type = 'absolute',
@@ -58,6 +58,8 @@ export const Drawer: FC<IDrawer> & { Button: FC<Overload<IButton>> } = ({
     style,
     ...props
 }: IDrawer) => {
+    gaurdApolloName(props, 'Drawer');
+
     const button = useRef<HTMLButtonElement | null>(null);
 
     // state variables
@@ -148,7 +150,7 @@ export const Drawer: FC<IDrawer> & { Button: FC<Overload<IButton>> } = ({
         });
 
         // format header and footer
-        const [, ...otherMenus] = formatted.get(Menu);
+        const [, ...otherMenus] = formatted.get('Menu');
 
         if (otherMenus.length) throw new Error('Dropdown can only have one immediate Menu');
 
@@ -158,4 +160,5 @@ export const Drawer: FC<IDrawer> & { Button: FC<Overload<IButton>> } = ({
     return <div {...props}>{renderAll(children)}</div>;
 };
 
+Drawer.defaultProps = { 'data-apollo': 'Drawer' };
 Drawer.Button = Button;

--- a/src/components/Drawer/overload/Button.tsx
+++ b/src/components/Drawer/overload/Button.tsx
@@ -4,19 +4,25 @@ import Overload from '../../../interfaces/Overload';
 
 import type { IButton as CIButton } from '../../Button/Button';
 import { Button as CButton } from '../../Button/Button';
+import { Apollo } from '../../../interfaces/Apollo';
+
+export interface IDrawerButton
+    extends Overload<Omit<CIButton, 'data-apollo'>>,
+        Apollo<'Drawer.Button'> {}
 
 /**
  * Formats button to be sub component of Dropdown
  *
  * @return Formatted Button Component
  */
-const Button: FC<Overload<CIButton>> = forwardRef(function Button(
+const Button: FC<Overload<IDrawerButton>> = forwardRef(function Button(
     {
         parentProps: { toggleDrawer, buttonRef, instant },
+        ['data-apollo']: apolloName,
         onClick,
         children,
         ...props
-    }: Overload<CIButton>,
+    }: Overload<IDrawerButton>,
     ref: ForwardedRef<HTMLButtonElement>
 ) {
     /**
@@ -28,12 +34,19 @@ const Button: FC<Overload<CIButton>> = forwardRef(function Button(
     };
 
     return (
-        <CButton {...props} ref={buttonRef || ref} onClick={handleClick} aria-expanded={instant}>
-            {children}
-        </CButton>
+        <span>
+            <CButton
+                {...props}
+                ref={buttonRef || ref}
+                onClick={handleClick}
+                aria-expanded={instant}
+            >
+                {children}
+            </CButton>
+        </span>
     );
 });
 
-Button.displayName = 'Drawer.Button';
+Button.defaultProps = { 'data-apollo': 'Drawer.Button' };
 
 export default Button;

--- a/src/components/Drawer/overload/Menu.tsx
+++ b/src/components/Drawer/overload/Menu.tsx
@@ -8,7 +8,7 @@ import { IMenu as CIMenu } from '../../Menu/Menu';
 import { Menu as CMenu } from '../../Menu/Menu';
 import { IDrawer } from '../Drawer';
 
-interface IMenu extends Overload<CIMenu>, IDrawer {}
+interface IMenu extends Overload<CIMenu>, Omit<IDrawer, 'data-apollo'> {}
 
 /**
  * Formats menu component to be styled like drawer menu

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,15 +1,17 @@
 import type { HTMLAttributes, FC } from 'react';
 import React, { useState, useRef } from 'react';
-import FormatChildren from '../../util/FormatChildren';
 import './Dropdown.css';
 
+import type { Apollo } from '../../interfaces/Apollo';
 import type { ComponentAlignment, ComponentOrientation } from '../../interfaces/Properties';
+import { gaurdApolloName } from '../../util/ErrorHandling';
+import FormatChildren from '../../util/FormatChildren';
 
 import Button from './overload/Button';
 import Icon from './overload/Icon';
 import Menu from './overload/Menu';
 
-export interface IDropdown extends HTMLAttributes<HTMLDivElement> {
+export interface IDropdown extends HTMLAttributes<HTMLDivElement>, Apollo<'Dropdown'> {
     /** Determines where the menu will appear from */
     anchor?: ComponentOrientation;
     /** Determines menu alignment, when orientation is left or right */
@@ -26,7 +28,10 @@ export const Dropdown: FC<IDropdown> = ({
     className = '',
     anchor = 'bottom',
     alignment = 'start',
+    ...props
 }) => {
+    gaurdApolloName(props, 'Dropdown');
+
     // reference to buttons
     const buttonRef = useRef<HTMLButtonElement>(null);
     const iconRef = useRef<HTMLSpanElement>(null);
@@ -54,8 +59,8 @@ export const Dropdown: FC<IDropdown> = ({
         const formatted = new FormatChildren(parentProps, { Button, Menu, Icon });
 
         // get button
-        const [icon, ...otherIcons]: JSX.Element[] = formatted.get(Icon);
-        const [button, ...otherButtons]: JSX.Element[] = formatted.get(Button);
+        const [icon, ...otherIcons]: JSX.Element[] = formatted.get('Icon');
+        const [button, ...otherButtons]: JSX.Element[] = formatted.get('Button');
 
         // handles multiple button and icon components cases
         if (icon) {
@@ -70,7 +75,7 @@ export const Dropdown: FC<IDropdown> = ({
         }
 
         // get menu
-        const [menu, ...otherMenus]: JSX.Element[] = formatted.get(Menu);
+        const [menu, ...otherMenus]: JSX.Element[] = formatted.get('Menu');
         if (!menu) throw new Error('Dropdown component needs menu');
         if (otherMenus.length) throw new Error('Dropdown component can only have one menu');
 
@@ -85,3 +90,5 @@ export const Dropdown: FC<IDropdown> = ({
 
     return renderDropdown();
 };
+
+Dropdown.defaultProps = { 'data-apollo': 'Dropdown' };

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,9 +1,12 @@
 import type { HTMLAttributes, ReactNode, FC } from 'react';
 import React from 'react';
-import Overload from '../../interfaces/Overload';
 import './Footer.css';
 
-export interface IFooter extends Overload<HTMLAttributes<HTMLDivElement>> {
+import type { Apollo } from '../../interfaces/Apollo';
+import type Overload from '../../interfaces/Overload';
+import { gaurdApolloName } from '../../util/ErrorHandling';
+
+export interface IFooter extends Overload<HTMLAttributes<HTMLDivElement>>, Apollo<'Footer'> {
     /** Can have children of any kind */
     children?: ReactNode;
 }
@@ -14,9 +17,13 @@ export interface IFooter extends Overload<HTMLAttributes<HTMLDivElement>> {
  * @return Footer component
  */
 export const Footer: FC<IFooter> = ({ children, className = '', parentProps, ...props }) => {
+    gaurdApolloName(props, 'Footer');
+
     return (
         <footer {...props} className={`apollo-component-library-footer-component ${className}`}>
             {parentProps?.renderAll ? parentProps?.renderAll(children) : children}
         </footer>
     );
 };
+
+Footer.defaultProps = { 'data-apollo': 'Footer' };

--- a/src/components/Group/Group.tsx
+++ b/src/components/Group/Group.tsx
@@ -1,15 +1,20 @@
 import type { HTMLAttributes, FC, CSSProperties, ChangeEvent } from 'react';
 import React, { ReactNode, useEffect } from 'react';
-import FormatChildren from '../../util/FormatChildren';
 import './Group.css';
+
+import type { Apollo } from '../../interfaces/Apollo';
+import type { FormGroupData, FormValidator } from '../../interfaces/Properties';
+import { gaurdApolloName } from '../../util/ErrorHandling';
+import FormatChildren from '../../util/FormatChildren';
 
 import { Text } from '../Text/Text';
 import Radio from './overload/Radio';
 import Checkbox from './overload/Checkbox';
 import View from './overload/View';
-import { FormGroupData, FormValidator } from '../../interfaces/Properties';
 
-export interface IGroup extends Omit<HTMLAttributes<HTMLFieldSetElement>, 'onChange'> {
+export interface IGroup
+    extends Omit<HTMLAttributes<HTMLFieldSetElement>, 'onChange'>,
+        Apollo<'Group'> {
     /** Group must contain element between tags */
     children: ReactNode;
     /** Identifies the group's selection */
@@ -60,6 +65,8 @@ export const Group: FC<IGroup> = ({
     errorMessage,
     ...props
 }) => {
+    gaurdApolloName(props, 'Group');
+
     // check if the user is using error message invalidly
     useEffect(() => {
         if (errorMessage?.length && !name?.length)
@@ -139,6 +146,8 @@ export const Group: FC<IGroup> = ({
         </>
     );
 };
+
+Group.defaultProps = { 'data-apollo': 'Group' };
 
 const labelTextStyle: CSSProperties = {
     paddingBottom: 5,

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,9 +1,12 @@
 import type { HTMLAttributes, ReactNode, FC } from 'react';
 import React from 'react';
-import Overload from '../../interfaces/Overload';
 import './Header.css';
 
-export interface IHeader extends Overload<HTMLAttributes<HTMLDivElement>> {
+import type { Apollo } from '../../interfaces/Apollo';
+import type Overload from '../../interfaces/Overload';
+import { gaurdApolloName } from '../../util/ErrorHandling';
+
+export interface IHeader extends Overload<HTMLAttributes<HTMLDivElement>>, Apollo<'Header'> {
     /** Can have children of any kind */
     children?: ReactNode;
 }
@@ -14,9 +17,13 @@ export interface IHeader extends Overload<HTMLAttributes<HTMLDivElement>> {
  * @return Header component
  */
 export const Header: FC<IHeader> = ({ parentProps, children, className = '', ...props }) => {
+    gaurdApolloName(props, 'Header');
+
     return (
         <header {...props} className={`apollo-component-library-header-component ${className}`}>
             {parentProps?.renderAll ? parentProps?.renderAll(children) : children}
         </header>
     );
 };
+
+Header.defaultProps = { 'data-apollo': 'Header' };

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,9 +1,12 @@
 import type { HTMLAttributes, FC, ForwardedRef, RefObject } from 'react';
 import React, { useEffect, forwardRef, useRef } from 'react';
-import * as CSS from 'csstype';
 import './Icon.css';
 
-export interface IIcon extends HTMLAttributes<HTMLParagraphElement> {
+import type { Apollo } from '../../interfaces/Apollo';
+import type * as CSS from 'csstype';
+import { gaurdApolloName } from '../../util/ErrorHandling';
+
+export interface IIcon extends HTMLAttributes<HTMLParagraphElement>, Apollo<'Icon'> {
     /** The icon name the user wants to render */
     name: string;
     /** Specification of an onClick method will convert icon into a button */
@@ -42,6 +45,8 @@ export const Icon: FC<IIcon> = forwardRef(function Icon(
     }: IIcon,
     ref: ForwardedRef<HTMLSpanElement>
 ) {
+    gaurdApolloName(props, 'Icon');
+
     // define a fallback ref
     const iconRef = useRef<HTMLSpanElement>(null);
 
@@ -82,6 +87,8 @@ export const Icon: FC<IIcon> = forwardRef(function Icon(
         </span>
     );
 });
+
+Icon.defaultProps = { 'data-apollo': 'Icon' };
 
 /**
  * Gets Icon style object

--- a/src/components/LoadingState/LoadingState.tsx
+++ b/src/components/LoadingState/LoadingState.tsx
@@ -2,9 +2,12 @@ import type { HTMLAttributes, FC } from 'react';
 import React, { useState, useEffect, ReactNode, useRef, CSSProperties } from 'react';
 import './LoadingState.css';
 
+import type { Apollo } from '../../interfaces/Apollo';
+import { gaurdApolloName } from '../../util/ErrorHandling';
+
 import { Text } from '../Text/Text';
 
-export interface ILoadingState extends HTMLAttributes<HTMLDivElement> {
+export interface ILoadingState extends HTMLAttributes<HTMLDivElement>, Apollo<'LoadingState'> {
     /**
      * Determines status of the progressbar where
      * progressFilled={0.1} => 10% filled progressbar
@@ -36,6 +39,8 @@ export const LoadingState: FC<ILoadingState> = ({
     label,
     ...props
 }) => {
+    gaurdApolloName(props, 'LoadingState');
+
     // ref
     const progressRef = useRef<HTMLHeadingElement>(null);
 
@@ -124,3 +129,5 @@ export const LoadingState: FC<ILoadingState> = ({
         </>
     );
 };
+
+LoadingState.defaultProps = { 'data-apollo': 'LoadingState' };

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -2,16 +2,18 @@ import type { CSSProperties, FC, HTMLAttributes, MouseEventHandler, ReactNode } 
 import React, { useEffect, useState, useRef } from 'react';
 import './Menu.css';
 
-import Overload from '../../interfaces/Overload';
+import type { Apollo } from '../../interfaces/Apollo';
+import type Overload from '../../interfaces/Overload';
 import type * as CSS from 'csstype';
 import FormatChildren from '../../util/FormatChildren';
+import { gaurdApolloName } from '../../util/ErrorHandling';
+import { handleOutsideClick } from '../../util/detectOutsideClick';
 
 import { Header } from '../Header/Header';
 import { Footer } from '../Footer/Footer';
 import Option from './overload/Option';
-import { handleOutsideClick } from '../../util/detectOutsideClick';
 
-export interface IMenu extends Overload<HTMLAttributes<HTMLDivElement>> {
+export interface IMenu extends Overload<HTMLAttributes<HTMLDivElement>>, Apollo<'Menu'> {
     /** Determines whether the menu is meant for navigation */
     navigation?: boolean;
     /** Determines the max height of the menu */
@@ -52,6 +54,8 @@ export const Menu: FC<IMenu> = ({
     label,
     ...props
 }) => {
+    gaurdApolloName(props, 'Menu');
+
     // refs
     const menu = useRef<HTMLDivElement>(null);
     const first = useRef<HTMLLIElement>(null);
@@ -93,17 +97,17 @@ export const Menu: FC<IMenu> = ({
 
         // get formatted children
         const formatted = new FormatChildren(parentProps, { Option, Header, Footer });
-        if (!hasOptions && formatted.get(Option).length) toggleHasOptions(true);
+        if (!hasOptions && formatted.get('Option').length) toggleHasOptions(true);
 
         // check if in application mode
         if (!hasOptions) {
             // check if there is a description
-            if (!formatted.get(Option).length && !description?.length)
+            if (!formatted.get('Option').length && !description?.length)
                 throw new Error('Menu with no Option components requires description prop');
         }
 
         // if it is extract the headers and footers
-        const extracted = formatted.extract({ Header, Footer });
+        const extracted = formatted.extract(['Header', 'Footer']);
         if (extracted.Header) {
             const {
                 Header: [header, ...otherHeaders],
@@ -155,6 +159,8 @@ export const Menu: FC<IMenu> = ({
         </div>
     );
 };
+
+Menu.defaultProps = { 'data-apollo': 'Menu' };
 
 /**
  * Gets menu style

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -2,9 +2,12 @@ import type { HTMLAttributes, FC } from 'react';
 import React, { useState, useEffect } from 'react';
 import './Modal.css';
 
+import type { Apollo } from '../../interfaces/Apollo';
+import { gaurdApolloName } from '../../util/ErrorHandling';
+
 import Dialog from './components/Dialog';
 
-export interface IModal extends HTMLAttributes<HTMLDivElement> {
+export interface IModal extends HTMLAttributes<HTMLDivElement>, Apollo<'Modal'> {
     /** Required ID for WCAG 2.0 compliance purposes */
     id: string;
     /** Requires descriptive label for WCAG 2.0 compliance purposes */
@@ -37,6 +40,8 @@ export const Modal: FC<IModal> = ({
     toggleModal,
     ...props
 }) => {
+    gaurdApolloName(props, 'Modal');
+
     // state variables
     const [display, toggleDisplay] = useState(open);
     const [effect, toggleEffect] = useState(open);
@@ -77,6 +82,8 @@ export const Modal: FC<IModal> = ({
         </>
     );
 };
+
+Modal.defaultProps = { 'data-apollo': 'Modal' };
 
 /**
  * Gets modal style object

--- a/src/components/Modal/components/Dialog.tsx
+++ b/src/components/Modal/components/Dialog.tsx
@@ -63,8 +63,8 @@ const Dialog: FC<IModal> = ({
         });
 
         // extract header and footer components
-        const headers = formatted.get(Header);
-        const footers = formatted.get(Footer);
+        const headers = formatted.get('Header');
+        const footers = formatted.get('Footer');
 
         // check that the appropriate amount of headers is found
         if (headers.length > 1) throw new Error('Modal can only have 1 Header component');
@@ -88,11 +88,11 @@ const Dialog: FC<IModal> = ({
                 <Icon name="close" onClick={toggleModal} style={iconStyle} />
             </Text>
             {description ? <Text id={`${id}-desc`}>{description}</Text> : null}
-            {formatted?.get(Header)[0]}
+            {formatted?.get('Header')[0]}
             <div className="apollo-component-library-modal-component-body">
                 {formatted?.getOther()}
             </div>
-            {formatted?.get(Footer)[0]}
+            {formatted?.get('Footer')[0]}
         </div>
     );
 };

--- a/src/components/Modal/overload/Footer.tsx
+++ b/src/components/Modal/overload/Footer.tsx
@@ -18,7 +18,7 @@ const Footer: FC<IFooter> = ({ parentProps: { children, ...parentProps }, ...pro
     const formattedFooter = new FormatChildren(allProps, { ButtonGroup });
 
     // format and extract button groups
-    const buttonGroups = formattedFooter.get(ButtonGroup);
+    const buttonGroups = formattedFooter.get('ButtonGroup');
 
     // check that there is no more than one button group
     if (buttonGroups.length > 1)

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -1,16 +1,21 @@
 import type { HTMLAttributes, ReactNode, FC } from 'react';
 import React, { CSSProperties, useState, useEffect, useRef } from 'react';
-import { ComponentSize } from '../../interfaces/Properties';
-import type { ComponentPosition, ComponentVerticalOrientation } from '../../interfaces/Properties';
-import * as CSS from 'csstype';
-
-import FormatChildren from '../../util/FormatChildren';
 import './NavigationBar.css';
+
+import type { Apollo } from '../../interfaces/Apollo';
+import type {
+    ComponentPosition,
+    ComponentVerticalOrientation,
+    ComponentSize,
+} from '../../interfaces/Properties';
+import type * as CSS from 'csstype';
+import FormatChildren from '../../util/FormatChildren';
+import { gaurdApolloName } from '../../util/ErrorHandling';
 
 import { Text } from '../Text/Text';
 import Section from './overload/Section';
 
-export interface INavigationBar extends HTMLAttributes<HTMLDivElement> {
+export interface INavigationBar extends HTMLAttributes<HTMLDivElement>, Apollo<'NavigationBar'> {
     /** If the component is not static, it will determine the orientation of the component */
     orientation?: ComponentVerticalOrientation;
     /** Determines the position of the component */
@@ -40,6 +45,8 @@ export const NavigationBar: FC<INavigationBar> = ({
     style,
     ...props
 }: INavigationBar) => {
+    gaurdApolloName(props, 'NavigationBar');
+
     // refs
     const navigationBar = useRef<HTMLDivElement>(null);
     // state
@@ -88,6 +95,8 @@ export const NavigationBar: FC<INavigationBar> = ({
         </div>
     );
 };
+
+NavigationBar.defaultProps = { 'data-apollo': 'NavigationBar' };
 
 /**
  * Gets the navigation style object

--- a/src/components/NavigationBar/overload/Section.tsx
+++ b/src/components/NavigationBar/overload/Section.tsx
@@ -35,7 +35,7 @@ const Section: FC<ISection> = ({
             setSectionChildren(
                 <Dropdown>
                     <Icon name="menu" clickable color={titleColor} />
-                    <Menu label="header_nav_menu">{formatted.get(Option)}</Menu>
+                    <Menu label="header_nav_menu">{formatted.get('Option')}</Menu>
                 </Dropdown>
             );
         }

--- a/src/components/Option/Option.tsx
+++ b/src/components/Option/Option.tsx
@@ -2,12 +2,16 @@ import { HTMLAttributes, FC, forwardRef, ForwardedRef, MouseEvent, RefObject } f
 import React, { useEffect, useRef } from 'react';
 import './Option.css';
 
-import Overload from '../../interfaces/Overload';
+import type { Apollo } from '../../interfaces/Apollo';
+import type Overload from '../../interfaces/Overload';
 import type { ComponentWrap } from '../../interfaces/Properties';
+import { gaurdApolloName } from '../../util/ErrorHandling';
 
 import { Text } from '../Text/Text';
 
-export interface IOption extends Overload<Omit<HTMLAttributes<HTMLElement>, 'onClick'>> {
+export interface IOption
+    extends Overload<Omit<HTMLAttributes<HTMLElement>, 'onClick'>>,
+        Apollo<'Option'> {
     /** Needs to have a string value in between tags */
     children: string;
     /** Can have onClick callback method */
@@ -30,6 +34,8 @@ export const Option: FC<IOption> = forwardRef(function Option(
     { children, parentProps, className, onClick, wrap, href, ...props }: IOption,
     ref
 ) {
+    gaurdApolloName(props, 'Option');
+
     // define a fallback ref
     const optionRef = useRef<HTMLLIElement>(null);
 
@@ -73,3 +79,5 @@ export const Option: FC<IOption> = forwardRef(function Option(
 
     return <>{wrap ? wrap(option) : option}</>;
 });
+
+Option.defaultProps = { 'data-apollo': 'Option' };

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -1,9 +1,13 @@
 import { HTMLAttributes, ReactNode, FC, useEffect, CSSProperties } from 'react';
 import React from 'react';
-import { Text } from '../Text/Text';
 import './Radio.css';
 
-export interface IRadio extends HTMLAttributes<HTMLInputElement> {
+import type { Apollo } from '../../interfaces/Apollo';
+import { gaurdApolloName } from '../../util/ErrorHandling';
+
+import { Text } from '../Text/Text';
+
+export interface IRadio extends HTMLAttributes<HTMLInputElement>, Apollo<'Radio'> {
     /** String that identifies the radio */
     id?: string;
     /** You can define an element pertaining to radio */
@@ -42,6 +46,8 @@ export const Radio: FC<IRadio> = ({
     id,
     ...props
 }) => {
+    gaurdApolloName(props, 'Radio');
+
     // check if the user can use error messages
     useEffect(() => {
         if (errorMessage?.length && !id?.length)
@@ -91,6 +97,8 @@ export const Radio: FC<IRadio> = ({
         </>
     );
 };
+
+Radio.defaultProps = { 'data-apollo': 'Radio' };
 
 const errorTextStyle: CSSProperties = {
     paddingTop: 5,

--- a/src/components/Section/Section.tsx
+++ b/src/components/Section/Section.tsx
@@ -1,9 +1,12 @@
 import type { HTMLAttributes, FC } from 'react';
 import React, { CSSProperties } from 'react';
-import Overload from '../../interfaces/Overload';
-import * as CSS from 'csstype';
 
-export interface ISection extends Overload<HTMLAttributes<HTMLDivElement>> {
+import type { Apollo } from '../../interfaces/Apollo';
+import type Overload from '../../interfaces/Overload';
+import type * as CSS from 'csstype';
+import { gaurdApolloName } from '../../util/ErrorHandling';
+
+export interface ISection extends Overload<HTMLAttributes<HTMLDivElement>>, Apollo<'Section'> {
     /** value that determines the flex style prop of section */
     flex?: CSS.Property.Flex;
     /** value that determines the height of section */
@@ -40,6 +43,8 @@ export const Section: FC<ISection> = ({
     alignItems,
     ...props
 }) => {
+    gaurdApolloName(props, 'Section');
+
     return (
         <div
             {...props}
@@ -50,6 +55,8 @@ export const Section: FC<ISection> = ({
         </div>
     );
 };
+
+Section.defaultProps = { 'data-apollo': 'Section' };
 
 /**
  * Gets section style objects from properties

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -1,10 +1,14 @@
 import type { HTMLAttributes, ReactNode, FC } from 'react';
 import React from 'react';
-import { StyleVariant } from '../../interfaces/Properties';
-import { Text } from '../Text/Text';
 import './Switch.css';
 
-export interface ISwitch extends HTMLAttributes<HTMLInputElement> {
+import type { Apollo } from '../../interfaces/Apollo';
+import type { StyleVariant } from '../../interfaces/Properties';
+
+import { Text } from '../Text/Text';
+import { gaurdApolloName } from '../../util/ErrorHandling';
+
+export interface ISwitch extends HTMLAttributes<HTMLInputElement>, Apollo<'Switch'> {
     /** Can assign text or element to switch */
     children: ReactNode;
     /** Determines whether the switch is disabled */
@@ -33,6 +37,8 @@ export const Switch: FC<ISwitch> = ({
     required,
     ...props
 }) => {
+    gaurdApolloName(props, 'Switch');
+
     return (
         <div className="apollo-component-library-switch-component-wrapper">
             <label className="apollo-component-library-switch-component-label">
@@ -54,3 +60,5 @@ export const Switch: FC<ISwitch> = ({
         </div>
     );
 };
+
+Switch.defaultProps = { 'data-apollo': 'Switch' };

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,10 +1,13 @@
 /* eslint-disable camelcase */
 import type { FC } from 'react';
 import React, { useState } from 'react';
-import * as CSS from 'csstype';
 import './Table.css';
 
-export interface ITable {
+import type { Apollo } from '../../interfaces/Apollo';
+import type * as CSS from 'csstype';
+import { gaurdApolloName } from '../../util/ErrorHandling';
+
+export interface ITable extends Apollo<'Table'> {
     /** width of desired table */
     width?: CSS.Property.Width;
     /** height of table in pixels */
@@ -32,12 +35,7 @@ export interface ITable {
     /** Defines the weight of the header text */
     headerTextFontWeight?: CSS.Property.FontWeight;
 }
-const btnStyle = {
-    backgroundColor: 'black',
-    color: 'white',
-    border: 'none',
-    padding: '5px 10px',
-};
+
 /**
  * Component that serves as an table for ease of templating
  *
@@ -56,7 +54,11 @@ export const Table: FC<ITable> = ({
     headerTextColor = 'white',
     headerTextTransform = 'uppercase',
     headerTextFontWeight = 'bolder',
+    ...props
 }) => {
+    gaurdApolloName(props, 'Table');
+
+    // state
     const [page, setPage] = useState(pageNum);
     const [sorteddata, setsorted] = useState(data);
 
@@ -159,11 +161,11 @@ export const Table: FC<ITable> = ({
                     {pageSize < data.length ? (
                         <tfoot className="apollo-component-library-table-component-footer">
                             <div>
-                                <button style={btnStyle} onClick={onBack}>
+                                <button style={buttonStyle} onClick={onBack}>
                                     Back
                                 </button>
                                 <label style={{ padding: '0 1em' }}>{page + 1}</label>
-                                <button style={btnStyle} onClick={onNext}>
+                                <button style={buttonStyle} onClick={onNext}>
                                     Next
                                 </button>
                             </div>
@@ -173,4 +175,14 @@ export const Table: FC<ITable> = ({
             )}
         </div>
     );
+};
+
+Table.defaultProps = { 'data-apollo': 'Table' };
+
+// style for button component
+const buttonStyle = {
+    backgroundColor: 'black',
+    color: 'white',
+    border: 'none',
+    padding: '5px 10px',
 };

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,9 +1,12 @@
 import type { HTMLAttributes, ReactNode, FC } from 'react';
 import React from 'react';
-import type * as CSS from 'csstype';
 import './Text.css';
 
-export interface IText extends HTMLAttributes<HTMLParagraphElement> {
+import type { Apollo } from '../../interfaces/Apollo';
+import type * as CSS from 'csstype';
+import { gaurdApolloName } from '../../util/ErrorHandling';
+
+export interface IText extends HTMLAttributes<HTMLParagraphElement>, Apollo<'Text'> {
     /** Text needs to exist between tags */
     children: ReactNode;
     /**
@@ -55,6 +58,8 @@ export const Text: FC<IText> = ({
     style,
     ...props
 }) => {
+    gaurdApolloName(props, 'Text');
+
     /**
      * Gets all the special conditions and translates it to a special className combination
      * granting all conditions
@@ -126,6 +131,8 @@ export const Text: FC<IText> = ({
         </span>
     );
 };
+
+Text.defaultProps = { 'data-apollo': 'Text' };
 
 /**
  * Gets text style object

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -1,12 +1,14 @@
 import type { HTMLAttributes, FC, CSSProperties } from 'react';
 import React, { useEffect } from 'react';
-
-import type { FormTextData, FormValidator, StyleVariant } from '../../interfaces/Properties';
 import './TextInput.css';
+
+import type { Apollo } from '../../interfaces/Apollo';
+import type { FormTextData, FormValidator, StyleVariant } from '../../interfaces/Properties';
+import { gaurdApolloName } from '../../util/ErrorHandling';
 
 import { Text } from '../Text/Text';
 
-export interface ITextInput extends HTMLAttributes<HTMLInputElement> {
+export interface ITextInput extends HTMLAttributes<HTMLInputElement>, Apollo<'TextInput'> {
     /** To comply with WCAG 2.0, all inputs **must** have labels */
     label: string;
     /** Gives further description on what the input should have to be valid */
@@ -49,6 +51,8 @@ export const TextInput: FC<ITextInput> = ({
     label,
     ...props
 }) => {
+    gaurdApolloName(props, 'TextInput');
+
     // will throw if you try to add an error message without a name
     useEffect(() => {
         if (errorMessage?.length && !name?.length)
@@ -94,6 +98,8 @@ export const TextInput: FC<ITextInput> = ({
         </div>
     );
 };
+
+TextInput.defaultProps = { 'data-apollo': 'TextInput' };
 
 const labelTextStyle: CSSProperties = {
     paddingBottom: 5,

--- a/src/components/View/View.tsx
+++ b/src/components/View/View.tsx
@@ -1,10 +1,12 @@
 import type { HTMLAttributes, ReactNode, FC, CSSProperties } from 'react';
 import React from 'react';
 
+import type { Apollo } from '../../interfaces/Apollo';
 import type Overload from '../../interfaces/Overload';
 import type * as CSS from 'csstype';
+import { gaurdApolloName } from '../../util/ErrorHandling';
 
-export interface IView extends Overload<HTMLAttributes<HTMLDivElement>> {
+export interface IView extends Overload<HTMLAttributes<HTMLDivElement>>, Apollo<'View'> {
     /** May have children */
     children?: ReactNode;
     /** Change the display style of View */
@@ -19,12 +21,16 @@ export interface IView extends Overload<HTMLAttributes<HTMLDivElement>> {
  * @return View component
  */
 export const View: FC<IView> = ({ parentProps, children, display, position, style, ...props }) => {
+    gaurdApolloName(props, 'View');
+
     return (
         <div {...props} style={getViewStyle({ display, position, style })}>
             {parentProps?.renderAll ? parentProps?.renderAll(children) : children}
         </div>
     );
 };
+
+View.defaultProps = { 'data-apollo': 'View' };
 
 /**
  * Gets the style object for the View given props

--- a/src/interfaces/Apollo.ts
+++ b/src/interfaces/Apollo.ts
@@ -1,0 +1,4 @@
+export type Apollo<N> = {
+    /** Identifies the component, this property should never be changed or removed */
+    'data-apollo'?: N;
+};

--- a/src/util/ErrorHandling.ts
+++ b/src/util/ErrorHandling.ts
@@ -1,0 +1,11 @@
+/**
+ * Will ensure that the component name is always correct, if it is not it will throw an error.
+ *
+ * @param props component properties
+ * @param name expected name of component
+ */
+export const gaurdApolloName = (props: any, name: string): void => {
+    if (props['data-apollo'] !== name) {
+        throw new Error(`Apollo component name must be ${name}`);
+    }
+};


### PR DESCRIPTION
# Changed Apollo's Identification method for Format Children
In this PR I am resolving all production and dev build issues regarding the `FormatChildren` algorithm.
- https://linear.app/milemarker10/issue/MIL-656/bug-build-time-minification-resolution

## Purpose
The purpose of this Pull Request is to resolve all issues regarding the `FormatChildren` algorithm. 

## Summary of Changes
In this pull request, I created a new data type called `Apollo`, which all components created in Apollo must extend. It's purpose is to add an extra property called `data-apollo` which holds the name of the component. This provided a way more safe identification method that allows us to sort through Apollo components and other elements alike.

# Certificate
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.