### PR TITLE
Extending Hybrid Features to the Client Form

### DIFF
--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -5,6 +5,7 @@ import './ButtonGroup.css';
 import FormatChildren from '../../util/FormatChildren';
 import type { Apollo } from '../../interfaces/Apollo';
 import type { StyleVariant, ComponentSize } from '../../interfaces/Properties';
+import type { RenderAll } from '../../interfaces/Overload';
 import { gaurdApolloName } from '../../util/ErrorHandling';
 
 import Button from './overload/Button';
@@ -39,9 +40,9 @@ export const ButtonGroup: FC<IButtonGroup> = ({
      *
      * @return formatted buttons
      */
-    const renderButtons = (): JSX.Element[] => {
+    const renderAll: RenderAll = () => {
         // get new formatted children
-        const formatted = new FormatChildren({ children, disabled, size, variant }, { Button });
+        const formatted = new FormatChildren(children, { Button }, { disabled, size, variant });
         if (formatted.getOther().length)
             throw new Error('ButtonGroup can only accept Buttons as children');
 
@@ -50,7 +51,7 @@ export const ButtonGroup: FC<IButtonGroup> = ({
 
     return (
         <div {...props} className={`apollo-component-library-button-group-component ${className}`}>
-            {renderButtons()}
+            {renderAll()}
         </div>
     );
 };

--- a/src/components/ButtonGroup/overload/Button.tsx
+++ b/src/components/ButtonGroup/overload/Button.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { IButton } from '../../Button/Button';
-import Overload from '../../../interfaces/Overload';
+import type { Overload } from '../../../interfaces/Overload';
 
 /**
  * Component that formats buttons in a way that groups them together

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -5,6 +5,7 @@ import './Card.css';
 import type { Apollo } from '../../interfaces/Apollo';
 import FormatChildren from '../../util/FormatChildren';
 import { gaurdApolloName } from '../../util/ErrorHandling';
+import type { RenderAll } from '../../interfaces/Overload';
 
 import { Header } from '../Header/Header';
 import { Footer } from '../Footer/Footer';
@@ -28,21 +29,17 @@ export const Card: FC<ICard> = ({ children, className, ...props }) => {
      *
      * @return html elements
      */
-    const renderAll = (): JSX.Element => {
+    const renderAll: RenderAll = () => {
         // get all the children from the components
-        const formatted = new FormatChildren({ children }, { Header, Footer });
+        const formatted = new FormatChildren(children, { Header, Footer });
 
         // extract header and footer
-        const headers = formatted.get('Header');
-        const footers = formatted.get('Footer');
+        const [header, ...otherHeaders] = formatted.get('Header');
+        const [footer, ...otherFooters] = formatted.get('Footer');
 
         // check to see that we have one footer and one header MAX
-        if (headers.length > 1) throw new Error('Card cannot have more than one header.');
-        if (footers.length > 1) throw new Error('Card cannot have more than one footer.');
-
-        // get the header and footer
-        const [header] = headers;
-        const [footer] = footers;
+        if (otherHeaders.length > 1) throw new Error('Card cannot have more than one header.');
+        if (otherFooters.length > 1) throw new Error('Card cannot have more than one footer.');
 
         // return the structured content
         return (

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -4,7 +4,8 @@ import FormatChildren from '../../util/FormatChildren';
 import './Drawer.css';
 
 import type { Apollo } from '../../interfaces/Apollo';
-import type { ComponentOrientation, ComponentRenderAll } from '../../interfaces/Properties';
+import type { ComponentOrientation } from '../../interfaces/Properties';
+import type { RenderAll } from '../../interfaces/Overload';
 import { gaurdApolloName } from '../../util/ErrorHandling';
 
 import { View } from '../View/View';
@@ -124,10 +125,12 @@ export const Drawer: FC<IDrawer> & { Button: FC<IDrawerButton> } = ({
      * @param childrenProp children property of the component needing formatting
      * @return render ready drawer component
      */
-    const renderAll: ComponentRenderAll = (childrenProp) => {
+    const renderAll: RenderAll = (childrenProp) => {
+        // overloaded components
+        const overloaded = { ['Drawer.Button']: Button, Menu, View };
+
         // define parent props
         const parentProps = {
-            children: childrenProp,
             orientation,
             type,
             modifiedDimension,
@@ -143,11 +146,7 @@ export const Drawer: FC<IDrawer> & { Button: FC<IDrawerButton> } = ({
         };
 
         // gets all found children
-        const formatted = new FormatChildren(parentProps, {
-            ['Drawer.Button']: Button,
-            Menu,
-            View,
-        });
+        const formatted = new FormatChildren(childrenProp, overloaded, parentProps);
 
         // format header and footer
         const [, ...otherMenus] = formatted.get('Menu');

--- a/src/components/Drawer/overload/Button.tsx
+++ b/src/components/Drawer/overload/Button.tsx
@@ -1,13 +1,13 @@
 import { FC, ForwardedRef, forwardRef } from 'react';
 import React from 'react';
-import Overload from '../../../interfaces/Overload';
+import type { Interface } from '../../../interfaces/Overload';
 
 import type { IButton as CIButton } from '../../Button/Button';
 import { Button as CButton } from '../../Button/Button';
 import { Apollo } from '../../../interfaces/Apollo';
 
 export interface IDrawerButton
-    extends Overload<Omit<CIButton, 'data-apollo'>>,
+    extends Interface<Omit<CIButton, 'data-apollo'>>,
         Apollo<'Drawer.Button'> {}
 
 /**
@@ -15,14 +15,14 @@ export interface IDrawerButton
  *
  * @return Formatted Button Component
  */
-const Button: FC<Overload<IDrawerButton>> = forwardRef(function Button(
+const Button: FC<IDrawerButton> = forwardRef(function Button(
     {
-        parentProps: { toggleDrawer, buttonRef, instant },
+        parentProps,
         ['data-apollo']: apolloName,
         onClick,
         children,
         ...props
-    }: Overload<IDrawerButton>,
+    }: Interface<IDrawerButton>,
     ref: ForwardedRef<HTMLButtonElement>
 ) {
     /**
@@ -30,16 +30,16 @@ const Button: FC<Overload<IDrawerButton>> = forwardRef(function Button(
      */
     const handleClick = (): void => {
         if (onClick) onClick();
-        toggleDrawer();
+        parentProps?.toggleDrawer();
     };
 
     return (
         <span>
             <CButton
                 {...props}
-                ref={buttonRef || ref}
+                ref={parentProps?.buttonRef || ref}
                 onClick={handleClick}
-                aria-expanded={instant}
+                aria-expanded={parentProps?.instant}
             >
                 {children}
             </CButton>

--- a/src/components/Drawer/overload/Menu.tsx
+++ b/src/components/Drawer/overload/Menu.tsx
@@ -1,7 +1,7 @@
 import type { CSSProperties, FC } from 'react';
 import React from 'react';
 
-import Overload from '../../../interfaces/Overload';
+import type { Overload } from '../../../interfaces/Overload';
 
 import { Icon } from '../../Icon/Icon';
 import { IMenu as CIMenu } from '../../Menu/Menu';

--- a/src/components/Drawer/overload/Option.tsx
+++ b/src/components/Drawer/overload/Option.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { IOption, Option as COption } from '../../Option/Option';
-import Overload from '../../../interfaces/Overload';
+import type { Overload } from '../../../interfaces/Overload';
 
 /**
  * Component that formats options pertaining to the Drawer

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -4,6 +4,7 @@ import './Dropdown.css';
 
 import type { Apollo } from '../../interfaces/Apollo';
 import type { ComponentAlignment, ComponentOrientation } from '../../interfaces/Properties';
+import type { RenderAll } from '../../interfaces/Overload';
 import { gaurdApolloName } from '../../util/ErrorHandling';
 import FormatChildren from '../../util/FormatChildren';
 
@@ -44,11 +45,10 @@ export const Dropdown: FC<IDropdown> = ({
      *
      * @return dropdown component
      */
-    const renderDropdown = (): JSX.Element => {
+    const renderDropdown: RenderAll = () => {
         // define parentProps props
         const parentProps = {
             button: buttonRef || iconRef,
-            children,
             open,
             anchor,
             alignment,
@@ -56,7 +56,7 @@ export const Dropdown: FC<IDropdown> = ({
         };
 
         // find all targeted components
-        const formatted = new FormatChildren(parentProps, { Button, Menu, Icon });
+        const formatted = new FormatChildren(children, { Button, Menu, Icon }, parentProps);
 
         // get button
         const [icon, ...otherIcons]: JSX.Element[] = formatted.get('Icon');
@@ -80,15 +80,17 @@ export const Dropdown: FC<IDropdown> = ({
         if (otherMenus.length) throw new Error('Dropdown component can only have one menu');
 
         return (
-            <div className={`apollo-component-library-dropdown ${className}`}>
+            <>
                 {(anchor === 'top' || anchor === 'left') && open ? menu : null}
                 {button || icon}
                 {(anchor === 'bottom' || anchor === 'right') && open ? menu : null}
-            </div>
+            </>
         );
     };
 
-    return renderDropdown();
+    return (
+        <div className={`apollo-component-library-dropdown ${className}`}>{renderDropdown()}</div>
+    );
 };
 
 Dropdown.defaultProps = { 'data-apollo': 'Dropdown' };

--- a/src/components/Dropdown/overload/Button.tsx
+++ b/src/components/Dropdown/overload/Button.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import React from 'react';
-import type Overload from '../../../interfaces/Overload';
+import type { Overload } from '../../../interfaces/Overload';
 
 import type { IButton as CIButton } from '../../Button/Button';
 import { Button as CButton } from '../../Button/Button';

--- a/src/components/Dropdown/overload/Icon.tsx
+++ b/src/components/Dropdown/overload/Icon.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import React from 'react';
 
-import Overload from '../../../interfaces/Overload';
+import type { Overload } from '../../../interfaces/Overload';
 
 import type { IIcon as CIIcon } from '../../Icon/Icon';
 import { Icon as CIcon } from '../../Icon/Icon';

--- a/src/components/Dropdown/overload/Menu.tsx
+++ b/src/components/Dropdown/overload/Menu.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, FC } from 'react';
 import React from 'react';
+import { Overload } from '../../../interfaces/Overload';
 
 import type { IMenu as CIMenu } from '../../Menu/Menu';
 import { Menu as CMenu } from '../../Menu/Menu';
@@ -9,7 +10,7 @@ import { Menu as CMenu } from '../../Menu/Menu';
  *
  * @return Dropdown Menu component
  */
-const Menu: FC<CIMenu> = ({
+const Menu: FC<Overload<CIMenu>> = ({
     parentProps: { toggleOpen, open, alignment, anchor, button },
     width = 300,
     useOutsideClick,
@@ -46,7 +47,9 @@ const Menu: FC<CIMenu> = ({
  *
  * @return gets the style
  */
-const getPortalStyle = ({ parentProps: { anchor } }: Omit<CIMenu, 'label'>): CSSProperties => {
+const getPortalStyle = ({
+    parentProps: { anchor },
+}: Omit<Overload<CIMenu>, 'label'>): CSSProperties => {
     const portalStyle: CSSProperties = { display: 'flex', position: 'relative' };
 
     if (anchor == 'top' || anchor == 'bottom') portalStyle.justifyContent = 'space-around';
@@ -64,7 +67,7 @@ const getStyle = ({
     style,
     width,
     parentProps: { alignment, anchor, button },
-}: Omit<CIMenu, 'label'>): CSSProperties => {
+}: Omit<Overload<CIMenu>, 'label'>): CSSProperties => {
     const menuStyle: CSSProperties = { position: 'absolute', ...style };
     const {
         current: { clientHeight: buttonHeight },

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -3,10 +3,10 @@ import React from 'react';
 import './Footer.css';
 
 import type { Apollo } from '../../interfaces/Apollo';
-import type Overload from '../../interfaces/Overload';
+import type { Interface } from '../../interfaces/Overload';
 import { gaurdApolloName } from '../../util/ErrorHandling';
 
-export interface IFooter extends Overload<HTMLAttributes<HTMLDivElement>>, Apollo<'Footer'> {
+export interface IFooter extends Interface<HTMLAttributes<HTMLDivElement>>, Apollo<'Footer'> {
     /** Can have children of any kind */
     children?: ReactNode;
 }

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -1,4 +1,4 @@
-import type { FC, HTMLAttributes } from 'react';
+import type { FC, HTMLProps } from 'react';
 import React from 'react';
 
 import type {
@@ -9,7 +9,7 @@ import type {
 import CSForm from './components/CSForm';
 import SSForm from './components/SSForm';
 
-export interface IForm extends Omit<HTMLAttributes<HTMLFormElement>, 'onSubmit' | 'onError'> {
+export interface IForm extends Omit<HTMLProps<HTMLFormElement>, 'onSubmit' | 'onError'> {
     /** Handles form submission with object derived from form */
     onSubmit?: FormSubmitHandler;
     /** Handles errors from form submission with error object */
@@ -18,9 +18,8 @@ export interface IForm extends Omit<HTMLAttributes<HTMLFormElement>, 'onSubmit' 
     type?: 'client' | 'remix';
     /** When in remix mode, this will control all the form inputs */
     actionData?: FormActionData;
-    /** Submission method, this doesn't do anything for client-side forms */
-    method?: 'GET' | 'POST';
 }
+
 /**
  * Apollo form component that allows for client side and server side validation
  *

--- a/src/components/Form/components/CSForm.tsx
+++ b/src/components/Form/components/CSForm.tsx
@@ -1,4 +1,4 @@
-import type { FC, FormEvent, FormEventHandler, HTMLProps, ReactNode } from 'react';
+import type { FC, FormEvent, FormEventHandler, HTMLProps } from 'react';
 import React from 'react';
 
 import type {
@@ -6,6 +6,7 @@ import type {
     FormSubmitHandler,
     FormActionData,
 } from '../../../interfaces/Properties';
+import type { RenderAll } from '../../../interfaces/Overload';
 import FormatChildren from '../../../util/FormatChildren';
 import { useForm } from 'react-hook-form';
 
@@ -49,12 +50,12 @@ const CSForm: FC<ICSForm> = ({ onSubmit, onError, children, actionData, method, 
      * @param passthrough parent props to be passed through the original parents
      * @return formatted children
      */
-    const renderAll = (
-        childrenProp: ReactNode,
-        passthrough: { [key: string]: boolean | number | string } = {}
-    ): JSX.Element[] => {
+    const renderAll: RenderAll = (childrenProp, passthrough): JSX.Element[] => {
+        // overloaded components
+        const overloaded = { TextInput, Group, Switch, Radio, Checkbox };
+
+        // parent props
         const parentProps = {
-            children: childrenProp,
             setError,
             clearErrors,
             setValue,
@@ -67,13 +68,7 @@ const CSForm: FC<ICSForm> = ({ onSubmit, onError, children, actionData, method, 
             ...passthrough,
         };
 
-        const formatted = new FormatChildren(parentProps, {
-            TextInput,
-            Group,
-            Switch,
-            Radio,
-            Checkbox,
-        });
+        const formatted = new FormatChildren(childrenProp, overloaded, parentProps);
 
         return formatted.getAll();
     };

--- a/src/components/Form/components/SSForm.tsx
+++ b/src/components/Form/components/SSForm.tsx
@@ -1,8 +1,9 @@
 import type { FC, HTMLAttributes } from 'react';
 import React from 'react';
 
-import { FormActionData } from '../../../interfaces/Properties';
 import FormatChildren from '../../../util/FormatChildren';
+import type { FormActionData } from '../../../interfaces/Properties';
+import type { RenderAll } from '../../../interfaces/Overload';
 
 import TextInput from '../overload/SSTextInput';
 import Checkbox from '../overload/SSCheckbox';
@@ -27,19 +28,11 @@ const SSForm: FC<ISSForm> = ({ actionData, children, ...props }) => {
      *
      * @return formatted children
      */
-    const renderAll = (): JSX.Element[] => {
-        const parentProps = {
-            children,
-            actionData,
-        };
+    const renderAll: RenderAll = () => {
+        // overloaded components
+        const overloaded = { TextInput, Checkbox, Radio, Switch, Group };
 
-        const formatted = new FormatChildren(parentProps, {
-            TextInput,
-            Group,
-            Switch,
-            Radio,
-            Checkbox,
-        });
+        const formatted = new FormatChildren(children, overloaded, { actionData });
 
         return formatted.getAll();
     };

--- a/src/components/Form/overload/CSCheckbox.tsx
+++ b/src/components/Form/overload/CSCheckbox.tsx
@@ -1,8 +1,9 @@
 import type { ChangeEvent, FC } from 'react';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import Overload from '../../../interfaces/Overload';
 import { FormToggleData } from '../../../interfaces/Properties';
+import { getFormError } from '../../../util/Form';
 
 import { Checkbox as CCheckbox, ICheckbox as CheckboxProps } from '../../Checkbox/Checkbox';
 
@@ -16,12 +17,15 @@ interface ICheckbox extends Overload<CheckboxProps> {
  * @return Formatted Checkbox compatible with form
  */
 const Checkbox: FC<ICheckbox> = ({
-    parentProps: { register, setValue, clearErrors, errors },
+    parentProps: { register, setValue, clearErrors, errors, actionData },
     onChange,
     required,
+    defaultChecked,
     id,
     ...props
 }) => {
+    const [ignoreFieldError, showFieldError] = useState(Boolean(!actionData?.fieldErrors?.[id]));
+
     // make sure that an id was provided
     useEffect(() => {
         if (!id) throw new Error('Must use Checkbox `id` prop when use in Form without Group');
@@ -36,6 +40,8 @@ const Checkbox: FC<ICheckbox> = ({
      * @param event input event on change
      */
     const handleChange = (event: ChangeEvent<HTMLInputElement>): void => {
+        if (!ignoreFieldError) showFieldError(true);
+
         const {
             target: { checked },
         } = event;
@@ -50,14 +56,17 @@ const Checkbox: FC<ICheckbox> = ({
         setValue(id, data);
     };
 
+    const error = getFormError(id, errors, actionData, ignoreFieldError);
+
     return (
         <CCheckbox
             {...props}
             id={id}
+            defaultChecked={actionData?.fields?.[id] || defaultChecked}
             required={required}
             onChange={handleChange}
-            invalid={Boolean(errors[id])}
-            errorMessage={errors[id]?.message}
+            invalid={Boolean(error.length)}
+            errorMessage={error}
         />
     );
 };

--- a/src/components/Form/overload/CSCheckbox.tsx
+++ b/src/components/Form/overload/CSCheckbox.tsx
@@ -1,7 +1,7 @@
 import type { ChangeEvent, FC } from 'react';
 import React, { useEffect, useState } from 'react';
 
-import Overload from '../../../interfaces/Overload';
+import type { Overload } from '../../../interfaces/Overload';
 import { FormToggleData } from '../../../interfaces/Properties';
 import { getFormError } from '../../../util/Form';
 

--- a/src/components/Form/overload/CSGroup.tsx
+++ b/src/components/Form/overload/CSGroup.tsx
@@ -1,7 +1,7 @@
 import type { ChangeEvent, FC, ReactNode } from 'react';
 import React, { useEffect, useState } from 'react';
 
-import Overload from '../../../interfaces/Overload';
+import type { Overload } from '../../../interfaces/Overload';
 import { FormGroupData } from '../../../interfaces/Properties';
 import { getFormError } from '../../../util/Form';
 
@@ -134,7 +134,7 @@ const Group: FC<IGroup> = ({
      * @return Appropriate group format
      */
     const renderGroup = (): JSX.Element[] | ReactNode => {
-        if (type === 'input') return children;
+        if (type === 'input' || !renderAll) return children;
 
         return renderAll(children);
     };

--- a/src/components/Form/overload/CSRadio.tsx
+++ b/src/components/Form/overload/CSRadio.tsx
@@ -1,8 +1,9 @@
 import type { ChangeEvent, FC } from 'react';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import Overload from '../../../interfaces/Overload';
 import { FormToggleData } from '../../../interfaces/Properties';
+import { getFormError } from '../../../util/Form';
 
 import { Radio as CRadio, IRadio as RadioProps } from '../../Radio/Radio';
 
@@ -16,12 +17,17 @@ interface IRadio extends Overload<RadioProps> {
  * @return Formatted Radio compatible with form
  */
 const Radio: FC<IRadio> = ({
-    parentProps: { register, setValue, clearErrors, errors },
+    parentProps: { register, setValue, clearErrors, errors, actionData },
     onChange,
     required,
+    defaultChecked,
     id,
     ...props
 }) => {
+    const [ignoreFieldError, setIgnoreFieldError] = useState(
+        Boolean(!actionData?.fieldErrors?.[id])
+    );
+
     // make sure that an id was provided
     useEffect(() => {
         if (!id) throw new Error('Must use Radio `id` prop when use in Form without Group');
@@ -36,6 +42,7 @@ const Radio: FC<IRadio> = ({
      * @param event input event on change
      */
     const handleChange = (event: ChangeEvent<HTMLInputElement>): void => {
+        if (!ignoreFieldError) setIgnoreFieldError(true);
         const {
             target: { checked },
         } = event;
@@ -50,14 +57,18 @@ const Radio: FC<IRadio> = ({
         setValue(id, data);
     };
 
+    // get error if any
+    const error = getFormError(id, errors, actionData, ignoreFieldError);
+
     return (
         <CRadio
             {...props}
             id={id}
             required={required}
+            defaultChecked={actionData?.fields?.[id] || defaultChecked}
             onChange={handleChange}
-            invalid={Boolean(errors[id])}
-            errorMessage={errors[id]?.message}
+            invalid={Boolean(error?.length)}
+            errorMessage={error}
         />
     );
 };

--- a/src/components/Form/overload/CSRadio.tsx
+++ b/src/components/Form/overload/CSRadio.tsx
@@ -1,7 +1,7 @@
 import type { ChangeEvent, FC } from 'react';
 import React, { useEffect, useState } from 'react';
 
-import Overload from '../../../interfaces/Overload';
+import type { Overload } from '../../../interfaces/Overload';
 import { FormToggleData } from '../../../interfaces/Properties';
 import { getFormError } from '../../../util/Form';
 

--- a/src/components/Form/overload/CSSwitch.tsx
+++ b/src/components/Form/overload/CSSwitch.tsx
@@ -1,7 +1,7 @@
 import type { ChangeEvent, FC } from 'react';
 import React, { useEffect } from 'react';
 
-import Overload from '../../../interfaces/Overload';
+import type { Overload } from '../../../interfaces/Overload';
 import { FormToggleData } from '../../../interfaces/Properties';
 
 import { Switch as CSwitch, ISwitch as SwitchProps } from '../../Switch/Switch';

--- a/src/components/Form/overload/CSSwitch.tsx
+++ b/src/components/Form/overload/CSSwitch.tsx
@@ -12,7 +12,8 @@ import { Switch as CSwitch, ISwitch as SwitchProps } from '../../Switch/Switch';
  * @return formatted switch component
  */
 const Switch: FC<Overload<SwitchProps>> = ({
-    parentProps: { setValue, register },
+    parentProps: { setValue, register, actionData },
+    defaultChecked,
     name,
     ...props
 }) => {
@@ -39,7 +40,14 @@ const Switch: FC<Overload<SwitchProps>> = ({
         setValue(name, data);
     };
 
-    return <CSwitch {...props} name={name} onChange={handleChange} />;
+    return (
+        <CSwitch
+            {...props}
+            name={name}
+            onChange={handleChange}
+            defaultChecked={actionData?.fields?.[name] || defaultChecked}
+        />
+    );
 };
 
 export default Switch;

--- a/src/components/Form/overload/CSTextInput.tsx
+++ b/src/components/Form/overload/CSTextInput.tsx
@@ -1,6 +1,6 @@
 import type { ChangeEvent, FC } from 'react';
 import React, { useEffect, useState } from 'react';
-import Overload from '../../../interfaces/Overload';
+import type { Overload } from '../../../interfaces/Overload';
 import { FormTextData } from '../../../interfaces/Properties';
 import { getFormError } from '../../../util/Form';
 

--- a/src/components/Form/overload/SSCheckbox.tsx
+++ b/src/components/Form/overload/SSCheckbox.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import React from 'react';
 
-import Overload from '../../../interfaces/Overload';
+import type { Overload } from '../../../interfaces/Overload';
 
 import { Checkbox as CCheckbox, ICheckbox as CheckboxProps } from '../../Checkbox/Checkbox';
 

--- a/src/components/Form/overload/SSCheckbox.tsx
+++ b/src/components/Form/overload/SSCheckbox.tsx
@@ -27,13 +27,8 @@ const Checkbox: FC<ICheckbox> = ({
     id,
     ...props
 }) => {
-    const isChecked: boolean = fields
-        ? groupName?.length
-            ? fields[groupName]?.filter((field: string) => field === value).length
-            : fields[id]
-        : false;
-
-    const errorMessage: string | undefined = fieldErrors ? fieldErrors[id] : undefined;
+    const isChecked: boolean = fields?.[id];
+    const errorMessage: string | undefined = fieldErrors?.[id] || '';
 
     return (
         <CCheckbox

--- a/src/components/Form/overload/SSGroup.tsx
+++ b/src/components/Form/overload/SSGroup.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import React, { useEffect } from 'react';
 
-import Overload from '../../../interfaces/Overload';
+import type { Overload } from '../../../interfaces/Overload';
 
 import type { IGroup as CIGroup } from '../../Group/Group';
 import { Group as CGroup } from '../../Group/Group';

--- a/src/components/Form/overload/SSGroup.tsx
+++ b/src/components/Form/overload/SSGroup.tsx
@@ -1,34 +1,22 @@
-import type { FC, CSSProperties } from 'react';
+import type { FC } from 'react';
 import React, { useEffect } from 'react';
 
 import Overload from '../../../interfaces/Overload';
-import FormatChildren from '../../../util/FormatChildren';
 
-import type { IGroup as GroupProps } from '../../Group/Group';
-import { Text } from '../../Text/Text';
-
-import Radio from './SSRadio';
-import Checkbox from './SSCheckbox';
-
-interface IGroup extends Overload<GroupProps> {
-    name: string;
-}
+import type { IGroup as CIGroup } from '../../Group/Group';
+import { Group as CGroup } from '../../Group/Group';
 
 /**
  * Formatted Group, will serve as passthrough for parent props when in remix validation mode
  *
  * @return formatted group that complies with remix validation
  */
-const Group: FC<IGroup> = ({
+const Group: FC<Overload<CIGroup>> = ({
     parentProps: { actionData = { fields: {}, fieldErrors: {} } },
     type = 'input',
-    disabled = false,
-    inline = false,
     children,
+    defaultChecked,
     name,
-    onChange,
-    label,
-    hint,
     required,
     ...props
 }) => {
@@ -38,89 +26,20 @@ const Group: FC<IGroup> = ({
         if (!name?.length) throw new Error('Must use Group `name` prop when using Form.');
     });
 
-    /**
-     * Formats children components and passes the parent props through
-     *
-     * @return formatted children
-     */
-    const renderAll = (): JSX.Element[] => {
-        const newParentProps = { children, groupName: name, actionData, groupInline: inline };
-        const formatted = new FormatChildren(newParentProps, { Radio, Checkbox });
-
-        return formatted.getAll();
-    };
-
     const errorMessage = actionData?.fieldErrors ? actionData?.fieldErrors[name] : undefined;
     const invalid: boolean = errorMessage?.length;
 
     return (
-        <>
-            <fieldset
-                {...props}
-                className={`apollo-component-library-group ${invalid ? 'invalid' : ''}`}
-                aria-errormessage={name ? `${name}-error` : undefined}
-                aria-invalid={invalid}
-            >
-                <legend>
-                    <Text
-                        bold
-                        style={labelTextStyle}
-                        header={type === 'input' ? 0 : 1}
-                        margins={type === 'organization' && !Boolean(hint)}
-                    >
-                        {label}{' '}
-                        {required ? (
-                            <Text color="red" inline>
-                                *
-                            </Text>
-                        ) : null}
-                    </Text>
-                    {hint ? (
-                        <Text style={getHintTextStyle(type)} margins={type === 'organization'}>
-                            {hint}
-                        </Text>
-                    ) : null}
-                </legend>
-                <div
-                    className={`
-                    apollo-component-library-group-wrapper 
-                    ${invalid ? 'invalid' : ''}
-                `}
-                >
-                    {renderAll()}
-                </div>
-                {invalid && errorMessage ? (
-                    <div role="alert" id={name ? `${name}-error` : undefined}>
-                        <Text color="#c90000" style={errorTextStyle}>
-                            {errorMessage}
-                        </Text>
-                    </div>
-                ) : null}
-            </fieldset>
-        </>
+        <CGroup
+            {...props}
+            name={name}
+            defaultValue={actionData.fields?.[name] || defaultChecked}
+            invalid={invalid}
+            errorMessage={errorMessage}
+        >
+            {children}
+        </CGroup>
     );
-};
-
-const labelTextStyle: CSSProperties = {
-    paddingBottom: 5,
-};
-
-/**
- * gets the hint text style given the type
- *
- * @param type type that describes what kind of group is being used
- * @return hint style object
- */
-const getHintTextStyle = (type: string): CSSProperties => {
-    return {
-        fontSize: type === 'organization' ? '1rem' : '0.9rem',
-        paddingBottom: 5,
-        marginTop: 0,
-    };
-};
-
-const errorTextStyle: CSSProperties = {
-    paddingTop: 5,
 };
 
 export default Group;

--- a/src/components/Form/overload/SSRadio.tsx
+++ b/src/components/Form/overload/SSRadio.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import React from 'react';
 
-import Overload from '../../../interfaces/Overload';
+import type { Overload } from '../../../interfaces/Overload';
 
 import { Radio as CRadio, IRadio as RadioProps } from '../../Radio/Radio';
 

--- a/src/components/Form/overload/SSRadio.tsx
+++ b/src/components/Form/overload/SSRadio.tsx
@@ -16,25 +16,19 @@ interface IRadio extends Overload<RadioProps> {
  */
 const Radio: FC<IRadio> = ({
     parentProps: {
-        groupName,
         actionData: { fields, fieldErrors },
         groupInline,
     },
+    defaultChecked,
     onChange,
     required,
-    name,
     value,
     inline,
     id,
     ...props
 }) => {
-    const isChecked: boolean = fields
-        ? groupName?.length
-            ? fields[groupName] === value
-            : fields[id]
-        : false;
-
-    const errorMessage: string | undefined = fieldErrors ? fieldErrors[id] : undefined;
+    const isChecked: boolean = fields?.[id];
+    const errorMessage: string | undefined = fieldErrors?.[id] || '';
 
     return (
         <CRadio
@@ -42,9 +36,8 @@ const Radio: FC<IRadio> = ({
             id={id}
             value={value}
             inline={groupInline || inline}
-            name={groupName}
             required={required}
-            defaultChecked={isChecked}
+            defaultChecked={isChecked || defaultChecked}
             invalid={Boolean(errorMessage?.length)}
             errorMessage={errorMessage}
         />

--- a/src/components/Form/overload/SSSwitch.tsx
+++ b/src/components/Form/overload/SSSwitch.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import React from 'react';
 
-import Overload from '../../../interfaces/Overload';
+import type { Overload } from '../../../interfaces/Overload';
 
 import { Switch as CSwitch, ISwitch as SwitchProps } from '../../Switch/Switch';
 

--- a/src/components/Form/overload/SSTextInput.tsx
+++ b/src/components/Form/overload/SSTextInput.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import React from 'react';
 
-import type Overload from '../../../interfaces/Overload';
+import type { Overload } from '../../../interfaces/Overload';
 
 import type { ITextInput as TextInputProps } from '../../TextInput/TextInput';
 import { TextInput as CTextInput } from '../../TextInput/TextInput';

--- a/src/components/Group/Group.tsx
+++ b/src/components/Group/Group.tsx
@@ -19,7 +19,7 @@ export interface IGroup
     /** Group must contain element between tags */
     children: ReactNode;
     /** Identifies the group's selection */
-    name?: string;
+    name: string;
     /** Method that impacts onChange */
     onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
     /** Determines whether inputs are disabled or not */
@@ -64,6 +64,7 @@ export const Group: FC<IGroup> = ({
     required,
     invalid,
     errorMessage,
+    defaultValue,
     ...props
 }) => {
     gaurdApolloName(props, 'Group');
@@ -92,6 +93,7 @@ export const Group: FC<IGroup> = ({
             renderAll,
             disabled,
             inline,
+            defaultValue,
         };
 
         // get all instances of the input

--- a/src/components/Group/Group.tsx
+++ b/src/components/Group/Group.tsx
@@ -4,6 +4,7 @@ import './Group.css';
 
 import type { Apollo } from '../../interfaces/Apollo';
 import type { FormGroupData, FormValidator } from '../../interfaces/Properties';
+import type { RenderAll } from '../../interfaces/Overload';
 import { gaurdApolloName } from '../../util/ErrorHandling';
 import FormatChildren from '../../util/FormatChildren';
 
@@ -84,12 +85,11 @@ export const Group: FC<IGroup> = ({
      * @param childrenProp implements children view when available
      * @return rendered components
      */
-    const renderAll = (childrenProp: ReactNode): ReactNode[] => {
-        // create updated prop values
+    const renderAll: RenderAll = (childrenProp) => {
+        // parent props
         const parentProps = {
             onChange,
             name,
-            children: childrenProp,
             renderAll,
             disabled,
             inline,
@@ -97,7 +97,7 @@ export const Group: FC<IGroup> = ({
         };
 
         // get all instances of the input
-        const formatted = new FormatChildren(parentProps, { Radio, Checkbox, View });
+        const formatted = new FormatChildren(childrenProp, { Radio, Checkbox, View }, parentProps);
 
         return formatted.getAll();
     };

--- a/src/components/Group/overload/Checkbox.tsx
+++ b/src/components/Group/overload/Checkbox.tsx
@@ -1,7 +1,7 @@
 import type { ChangeEvent, FC } from 'react';
 import React from 'react';
 import { ICheckbox, Checkbox as CCheckbox } from '../../Checkbox/Checkbox';
-import Overload from '../../../interfaces/Overload';
+import type { Overload } from '../../../interfaces/Overload';
 
 /**
  * Overloaded Checkbox formatted to update group value on change

--- a/src/components/Group/overload/Checkbox.tsx
+++ b/src/components/Group/overload/Checkbox.tsx
@@ -9,7 +9,14 @@ import Overload from '../../../interfaces/Overload';
  * @return Formatted Checkbox
  */
 const Checkbox: FC<Overload<ICheckbox>> = ({
-    parentProps: { name, onChange: groupOnChange, disabled: parentDisabled, inline: parentInline },
+    parentProps: {
+        name,
+        onChange: groupOnChange,
+        disabled: parentDisabled,
+        inline: parentInline,
+        defaultValue: groupDefaultValue,
+    },
+    defaultChecked,
     onChange,
     disabled,
     value,
@@ -29,10 +36,27 @@ const Checkbox: FC<Overload<ICheckbox>> = ({
         if (onChange) onChange(event);
     };
 
+    /**
+     * Gets the default value of the checkbox
+     *
+     * @return default checkbox value
+     */
+    const getDefaultValue = (): boolean => {
+        if (
+            !groupDefaultValue ||
+            typeof groupDefaultValue !== 'object' ||
+            !Array.isArray(groupDefaultValue)
+        )
+            return false;
+
+        return Boolean(groupDefaultValue.filter((v: string) => v === value).length);
+    };
+
     return (
         <CCheckbox
             {...props}
             value={value}
+            defaultChecked={getDefaultValue() || defaultChecked}
             name={name}
             inline={parentInline}
             disabled={parentDisabled || disabled}

--- a/src/components/Group/overload/Radio.tsx
+++ b/src/components/Group/overload/Radio.tsx
@@ -9,7 +9,14 @@ import Overload from '../../../interfaces/Overload';
  * @return Formatted Radio
  */
 const Radio: FC<Overload<IRadio>> = ({
-    parentProps: { disabled: parentDisabled, onChange: groupOnChange, name, inline: parentInline },
+    parentProps: {
+        disabled: parentDisabled,
+        onChange: groupOnChange,
+        name,
+        inline: parentInline,
+        defaultValue: groupDefaultValue,
+    },
+    defaultChecked,
     onChange,
     disabled,
     value,
@@ -29,12 +36,24 @@ const Radio: FC<Overload<IRadio>> = ({
         if (onChange) onChange(event);
     };
 
+    /**
+     * Gets the default value of the component
+     *
+     * @return boolean default value
+     */
+    const getDefaultValue = (): boolean => {
+        if (typeof groupDefaultValue !== 'string') return false;
+
+        return groupDefaultValue === value;
+    };
+
     return (
         <CRadio
             {...props}
             name={name}
             value={value}
             inline={parentInline}
+            defaultChecked={getDefaultValue() || defaultChecked}
             disabled={parentDisabled || disabled}
             onChange={radioOnChange}
         />

--- a/src/components/Group/overload/Radio.tsx
+++ b/src/components/Group/overload/Radio.tsx
@@ -1,7 +1,7 @@
 import type { ChangeEvent, FC } from 'react';
 import React from 'react';
 import { IRadio, Radio as CRadio } from '../../Radio/Radio';
-import Overload from '../../../interfaces/Overload';
+import type { Overload } from '../../../interfaces/Overload';
 
 /**
  * Overloaded Radio formatted to update group value on change

--- a/src/components/Group/overload/View.tsx
+++ b/src/components/Group/overload/View.tsx
@@ -1,19 +1,21 @@
-import type { HTMLAttributes, FC } from 'react';
+import type { FC } from 'react';
 import React from 'react';
 import { View as CView } from '../../View/View';
-import Overload from '../../../interfaces/Overload';
+
+import type { IView as CIView } from '../../View/View';
+import type { Overload } from '../../../interfaces/Overload';
 
 /**
  * Overloaded view component formatted to pass through group modifiers to enable more complex layout
  *
  * @return formatted view
  */
-const View: FC<Overload<HTMLAttributes<HTMLDivElement>>> = ({
+const View: FC<Overload<CIView>> = ({
     parentProps: { renderAll },
     children,
     ...props
-}: Overload<HTMLAttributes<HTMLDivElement>>): JSX.Element => {
-    return <CView {...props}>{renderAll(children)}</CView>;
+}): JSX.Element => {
+    return <CView {...props}>{renderAll ? renderAll(children) : null}</CView>;
 };
 
 export default View;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -3,10 +3,10 @@ import React from 'react';
 import './Header.css';
 
 import type { Apollo } from '../../interfaces/Apollo';
-import type Overload from '../../interfaces/Overload';
+import type { Interface } from '../../interfaces/Overload';
 import { gaurdApolloName } from '../../util/ErrorHandling';
 
-export interface IHeader extends Overload<HTMLAttributes<HTMLDivElement>>, Apollo<'Header'> {
+export interface IHeader extends Interface<HTMLAttributes<HTMLDivElement>>, Apollo<'Header'> {
     /** Can have children of any kind */
     children?: ReactNode;
 }

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import './Menu.css';
 
 import type { Apollo } from '../../interfaces/Apollo';
-import type Overload from '../../interfaces/Overload';
+import type { RenderAll, Interface } from '../../interfaces/Overload';
 import type * as CSS from 'csstype';
 import FormatChildren from '../../util/FormatChildren';
 import { gaurdApolloName } from '../../util/ErrorHandling';
@@ -13,7 +13,7 @@ import { Header } from '../Header/Header';
 import { Footer } from '../Footer/Footer';
 import Option from './overload/Option';
 
-export interface IMenu extends Overload<HTMLAttributes<HTMLDivElement>>, Apollo<'Menu'> {
+export interface IMenu extends Interface<HTMLAttributes<HTMLDivElement>>, Apollo<'Menu'> {
     /** Determines whether the menu is meant for navigation */
     navigation?: boolean;
     /** Determines the max height of the menu */
@@ -92,11 +92,12 @@ export const Menu: FC<IMenu> = ({
      *
      * @return Formatted children
      */
-    const renderAll = (): JSX.Element[] => {
+    const renderAll: RenderAll = () => {
+        // parent props
         const parentProps = { children, first, last, handleOptionClick };
 
         // get formatted children
-        const formatted = new FormatChildren(parentProps, { Option, Header, Footer });
+        const formatted = new FormatChildren(children, { Option, Header, Footer }, parentProps);
         if (!hasOptions && formatted.get('Option').length) toggleHasOptions(true);
 
         // check if in application mode

--- a/src/components/Menu/overload/Option.tsx
+++ b/src/components/Menu/overload/Option.tsx
@@ -1,5 +1,6 @@
 import type { FC, MouseEvent, RefObject } from 'react';
 import React from 'react';
+import { Overload } from '../../../interfaces/Overload';
 
 import type { IOption } from '../../Option/Option';
 import { Option as COption } from '../../Option/Option';
@@ -9,7 +10,7 @@ import { Option as COption } from '../../Option/Option';
  *
  * @return Formatted option
  */
-const Option: FC<IOption> = ({
+const Option: FC<Overload<IOption>> = ({
     parentProps: { childTypeIndex, getChildTypeSize, first, last, handleOptionClick },
     onClick,
     children,

--- a/src/components/Modal/components/Dialog.tsx
+++ b/src/components/Modal/components/Dialog.tsx
@@ -54,13 +54,14 @@ const Dialog: FC<IModal> = ({
      * @return formatted
      */
     const getFormatted = (): FormatChildren => {
+        // overloaded
+        const overloaded = { Header, Footer };
+
+        // parent props
         const parentProps = { children, manual, toggleModal, open };
 
         // find all specified components
-        const formatted = new FormatChildren(parentProps, {
-            Header,
-            Footer,
-        });
+        const formatted = new FormatChildren(children, overloaded, parentProps);
 
         // extract header and footer components
         const headers = formatted.get('Header');

--- a/src/components/Modal/overload/Button.tsx
+++ b/src/components/Modal/overload/Button.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import React from 'react';
-import Overload from '../../../interfaces/Overload';
+import type { Overload } from '../../../interfaces/Overload';
 import { IButton } from '../../Button/Button';
 
 /**

--- a/src/components/Modal/overload/ButtonGroup.tsx
+++ b/src/components/Modal/overload/ButtonGroup.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import React from 'react';
-import Overload from '../../../interfaces/Overload';
+import type { Overload } from '../../../interfaces/Overload';
 import FormatChildren from '../../../util/FormatChildren';
 
 import Button from './Button';
@@ -12,15 +12,16 @@ import { IButtonGroup } from '../../ButtonGroup/ButtonGroup';
  * @return Formatted ButtonGroup
  */
 const ButtonGroup: FC<Overload<IButtonGroup>> = ({
-    parentProps: { children, ...parentProps },
+    parentProps: { ...parentProps },
     className = '',
+    children,
     ...props
 }: Overload<IButtonGroup>) => {
     // get all props
     const allProps = { ...props, ...parentProps };
 
     // find the buttons in the button group
-    const formattedButtonGroup = new FormatChildren(allProps, { Button });
+    const formattedButtonGroup = new FormatChildren(children, { Button }, allProps);
 
     // check that there are only buttons in the button group
     if (formattedButtonGroup.getOther().length > 0)

--- a/src/components/Modal/overload/Footer.tsx
+++ b/src/components/Modal/overload/Footer.tsx
@@ -10,12 +10,12 @@ import { IFooter, Footer as CFooter } from '../../Footer/Footer';
  *
  * @return formatted footer
  */
-const Footer: FC<IFooter> = ({ parentProps: { children, ...parentProps }, ...props }: IFooter) => {
+const Footer: FC<IFooter> = ({ parentProps, children, ...props }: IFooter) => {
     // gets all props
     const allProps = { ...props, ...parentProps };
 
     // find button groups
-    const formattedFooter = new FormatChildren(allProps, { ButtonGroup });
+    const formattedFooter = new FormatChildren(children, { ButtonGroup }, allProps);
 
     // format and extract button groups
     const buttonGroups = formattedFooter.get('ButtonGroup');

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -14,6 +14,7 @@ import { gaurdApolloName } from '../../util/ErrorHandling';
 
 import { Text } from '../Text/Text';
 import Section from './overload/Section';
+import { RenderAll } from '../../interfaces/Overload';
 
 export interface INavigationBar extends HTMLAttributes<HTMLDivElement>, Apollo<'NavigationBar'> {
     /** If the component is not static, it will determine the orientation of the component */
@@ -65,9 +66,9 @@ export const NavigationBar: FC<INavigationBar> = ({
      *
      * @return formatted components
      */
-    const renderAll = (): JSX.Element[] => {
+    const renderAll: RenderAll = () => {
         const parentProps = { children, mobile };
-        const formatted = new FormatChildren(parentProps, { Section });
+        const formatted = new FormatChildren(children, { Section }, parentProps);
 
         return formatted.getAll();
     };

--- a/src/components/NavigationBar/overload/Section.tsx
+++ b/src/components/NavigationBar/overload/Section.tsx
@@ -4,6 +4,7 @@ import { ISection, Section as CSection } from '../../Section/Section';
 
 import FormatChildren from '../../../util/FormatChildren';
 import { Dropdown, Option, Menu, Icon } from '../../..';
+import { Overload } from '../../../interfaces/Overload';
 
 /**
  * Formats section so that when it is in navigation mode, it will shrink to a hamburger
@@ -11,7 +12,7 @@ import { Dropdown, Option, Menu, Icon } from '../../..';
  *
  * @return Formatted section component
  */
-const Section: FC<ISection> = ({
+const Section: FC<Overload<ISection>> = ({
     parentProps: { mobile, titleColor },
     children,
     navigation,
@@ -22,8 +23,7 @@ const Section: FC<ISection> = ({
 
     useEffect(() => {
         if (mobile && navigation) {
-            const parentProps = { children };
-            const formatted = new FormatChildren(parentProps, { Option });
+            const formatted = new FormatChildren(children, { Option });
 
             // check if there are other types other than options
             if (formatted.getOther().length !== 0) {

--- a/src/components/Option/Option.tsx
+++ b/src/components/Option/Option.tsx
@@ -3,14 +3,14 @@ import React, { useEffect, useRef } from 'react';
 import './Option.css';
 
 import type { Apollo } from '../../interfaces/Apollo';
-import type Overload from '../../interfaces/Overload';
+import type { Interface } from '../../interfaces/Overload';
 import type { ComponentWrap } from '../../interfaces/Properties';
 import { gaurdApolloName } from '../../util/ErrorHandling';
 
 import { Text } from '../Text/Text';
 
 export interface IOption
-    extends Overload<Omit<HTMLAttributes<HTMLElement>, 'onClick'>>,
+    extends Interface<Omit<HTMLAttributes<HTMLElement>, 'onClick'>>,
         Apollo<'Option'> {
     /** Needs to have a string value in between tags */
     children: string;

--- a/src/components/Section/Section.tsx
+++ b/src/components/Section/Section.tsx
@@ -2,11 +2,11 @@ import type { HTMLAttributes, FC } from 'react';
 import React, { CSSProperties } from 'react';
 
 import type { Apollo } from '../../interfaces/Apollo';
-import type Overload from '../../interfaces/Overload';
+import type { Interface } from '../../interfaces/Overload';
 import type * as CSS from 'csstype';
 import { gaurdApolloName } from '../../util/ErrorHandling';
 
-export interface ISection extends Overload<HTMLAttributes<HTMLDivElement>>, Apollo<'Section'> {
+export interface ISection extends Interface<HTMLAttributes<HTMLDivElement>>, Apollo<'Section'> {
     /** value that determines the flex style prop of section */
     flex?: CSS.Property.Flex;
     /** value that determines the height of section */
@@ -51,7 +51,7 @@ export const Section: FC<ISection> = ({
             className={className}
             style={getSectionStyle(flex, height, width, alignItems, justifyContent, style)}
         >
-            {children}
+            {parentProps?.renderAll ? parentProps?.renderAll(children) : children}
         </div>
     );
 };

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -32,6 +32,10 @@ export interface ITextInput extends HTMLAttributes<HTMLInputElement>, Apollo<'Te
     name?: string;
     /** Message displayed when input is invalid */
     errorMessage?: string;
+    /** choose an input that the string value must match */
+    match?: string;
+    /** Choose error message for when input doesn't match */
+    matchMessage?: string;
 }
 
 /**
@@ -44,9 +48,11 @@ export const TextInput: FC<ITextInput> = ({
     className = '',
     password = false,
     invalid = false,
-    name,
     errorMessage,
+    matchMessage,
+    match,
     required,
+    name,
     id,
     hint,
     label,

--- a/src/components/View/View.tsx
+++ b/src/components/View/View.tsx
@@ -2,11 +2,11 @@ import type { HTMLAttributes, ReactNode, FC, CSSProperties } from 'react';
 import React from 'react';
 
 import type { Apollo } from '../../interfaces/Apollo';
-import type Overload from '../../interfaces/Overload';
+import type { Interface } from '../../interfaces/Overload';
 import type * as CSS from 'csstype';
 import { gaurdApolloName } from '../../util/ErrorHandling';
 
-export interface IView extends Overload<HTMLAttributes<HTMLDivElement>>, Apollo<'View'> {
+export interface IView extends Interface<HTMLAttributes<HTMLDivElement>>, Apollo<'View'> {
     /** May have children */
     children?: ReactNode;
     /** Change the display style of View */

--- a/src/interfaces/Overload.ts
+++ b/src/interfaces/Overload.ts
@@ -1,9 +1,50 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Function that is responsible for rendering all formatted children. This method can also be used
+ * in a child component to format children the same way as the parent component by passing the
+ * child's children as a parameter.
+ *
+ * @param children the children to format
+ * @param passthrough additional children to be passed by parent. Use if you want to use the same
+ * formatting as the old parent component while adding additional props from new parent.
+ * @return formatted children
+ */
+export type RenderAll = (
+    children?: ReactNode,
+    passthrough?: { [key: string]: any }
+) => Array<JSX.Element> | JSX.Element;
+
+/** Parent props to be passed down to children */
+export type ParentProps = {
+    /** any props passed down by parent */
+    [propName: string]: any;
+    /** Function that replicates parent's method for formatting children */
+    renderAll?: RenderAll;
+    /** Index of the child in reference to its order in the DOM */
+    childIndex?: number;
+    /**
+     * Index of the child in reference to the other children of the same component type in the
+     * DOM
+     */
+    childTypeIndex?: number;
+    /** Get the total amount of children of the same component type in the parent component */
+    getChildrenTypeSize?: () => number;
+    /** Get the total amount of children in the parent component*/
+    getChildrenSize?: () => number;
+};
+
 /**
  * Overloads parent components for use in overload components
  */
-type Overload<Props extends { [value: string]: any }> = Props & {
+export type Overload<Props extends { [value: string]: any }> = Props & {
     /** Props inherited by parents */
-    parentProps?: any;
+    parentProps: ParentProps;
 };
 
-export default Overload;
+/**
+ * Describes an interfacing component
+ */
+export type Interface<Props extends { [value: string]: any }> = Props & {
+    parentProps?: ParentProps;
+};

--- a/src/interfaces/Properties.ts
+++ b/src/interfaces/Properties.ts
@@ -11,12 +11,6 @@ export type ComponentAlignment = 'start' | 'center' | 'end';
 export type ComponentPosition = 'static' | 'absolute' | 'fixed';
 export type ComponentWrap = (component: ReactNode) => ReactNode;
 
-/**
- * Function used to format children. When in `parentProps`, this method will perpatuate the
- * original RenderAll component
- */
-export type ComponentRenderAll = (children?: ReactNode) => JSX.Element[];
-
 /* Form Types */
 
 // input data

--- a/src/interfaces/Properties.ts
+++ b/src/interfaces/Properties.ts
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { BaseSyntheticEvent, ReactNode } from 'react';
 
 /** Component Property types */
 export type StyleVariant = 'default' | 'secondary';
@@ -58,14 +58,14 @@ export type FormErrors = {
  *
  * @param data information collected from all form inputs
  */
-export type FormSubmitHandler = (data: FormData) => void;
+export type FormSubmitHandler = (data?: FormData, event?: BaseSyntheticEvent) => void;
 
 /**
  * Method that allows user to see all error messages when there is an invalid submission
  *
  * @param errors error messages collected from all inputs
  */
-export type FormErrorHandler = (errors: FormErrors) => void;
+export type FormErrorHandler = (errors?: FormErrors) => void;
 
 /** Function to be used for Apollo input validation purposes */
 export type FormValidator<T = FormInputData> = (inputData: T) => string | null;

--- a/src/util/Form.ts
+++ b/src/util/Form.ts
@@ -1,0 +1,35 @@
+import type { FormActionData, FormErrors } from '../interfaces/Properties';
+
+/**
+ * Gets the form action data from the form.
+ *
+ * @param name name of the input
+ * @param errors error to be analyzed
+ * @param actionData action data to be analyzed
+ * @param ignoreActionData value of the input
+ * @return the error message
+ */
+export const getFormError = (
+    name: string,
+    errors: FormErrors,
+    actionData?: FormActionData,
+    ignoreActionData?: boolean
+): string => {
+    // get field error if applicable
+    const fieldError: string = actionData?.fieldErrors?.[name] || '';
+
+    // check if there is a field error and if there is no change between current and previous values
+    if (fieldError.length && !ignoreActionData) {
+        return fieldError;
+    }
+
+    // get general error if applicable
+    const generalError: string = errors?.[name]?.message || '';
+
+    // check if there is a general error
+    if (generalError.length) {
+        return generalError;
+    }
+
+    return '';
+};

--- a/src/util/FormatChildren.tsx
+++ b/src/util/FormatChildren.tsx
@@ -1,4 +1,5 @@
 import React, { Children } from 'react';
+import { ParentProps } from '../interfaces/Overload';
 
 /** Object categorizing all found components by name */
 export interface FoundChildren {
@@ -19,22 +20,22 @@ export interface ComponentMap {
 }
 
 class FormatChildren {
+    /** an object containing all subsets of children organized by apollo name */
     foundChildren: FoundChildren = { other: [] };
+    /** all cihldren */
     allChildren: JSX.Element[] = [];
 
     /**
      * Given the props pertaining to the parent component and the sought out children, this
      * constructor will identify and format them.
      *
-     * @param parentProps props pertaining to the parent component
+     * @param children Children property
      * @param componentMap these are formatted components with the same name as the sought out
      * components. When found by this constructor, the sought out will be replaced by the
      * formatted.
+     * @param parentProps props pertaining to the parent component
      */
-    constructor(parentProps: any, componentMap: ComponentMap = {}) {
-        // destructure children from parent props
-        const { children } = parentProps;
-
+    constructor(children: any, componentMap: ComponentMap = {}, parentProps: ParentProps = {}) {
         // loop through all children
         Children.forEach(children, (child: JSX.Element, index: number) => {
             const childName =
@@ -51,13 +52,7 @@ class FormatChildren {
 
                 // get required props
                 const {
-                    props: {
-                        parentProps: childParentProps,
-                        key: childKey,
-                        originalType,
-                        mdxType,
-                        ...childProps
-                    },
+                    props: { parentProps: childParentProps, key: childKey, ...childProps },
                 } = child;
 
                 // assign props and finalize component format

--- a/stories/ErrorMessage.stories.mdx
+++ b/stories/ErrorMessage.stories.mdx
@@ -36,7 +36,7 @@ you will be able to see it.
 ## Setup
 
 In the case you want to use the `ErrorMessage`, make sure that the element the error is being 
-displayed for has its `aria-errorMessage` prop set to the `id` of this component. This will tell
+displayed for has its `aria-errormessage` prop set to the `id` of this component. This will tell
 the user where the error came from.
 
 <Canvas>

--- a/stories/Form.stories.mdx
+++ b/stories/Form.stories.mdx
@@ -1,8 +1,14 @@
 import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs';
 import { linkTo } from '@storybook/addon-links';
-import { Form, TextInput, Button, Group, Radio, Checkbox, Switch } from '../src';
+import { Form } from '../src';
 
-import { BasicForm, ValidatedForm, RemixForm } from './examples/Form';
+import {
+    BasicForm,
+    ValidatedForm,
+    RemixForm,
+    ClientSideRemixForm,
+    clientActionData,
+} from './examples/Form';
 
 <Meta title="Form/Form" component={Form} />
 
@@ -22,6 +28,9 @@ Here is a list of components you should check out to get started with the form:
 -   [Switch](?path=/docs/form-switch--default)
 -   [TextInput](?path=/docs/form-text-input--default)
 
+Also, we want to shout out `react-hook-form` for helping us make this component. Check them out
+[here](https://react-hook-form.com/).
+
 ## Table of Contents
 
 -   [Functionality](#functionality)
@@ -31,6 +40,7 @@ Here is a list of components you should check out to get started with the form:
         -   [onError](#onerror)
         -   [Basic Implementation](#basic-implementation)
         -   [Validation](#validation)
+        -   [Adding actionData](#adding-actiondata)
     -   [Remix Form Functionality](#remix-form-1)
 -   [Other Props & Functionalities](#other-props--functionalities)
 
@@ -41,10 +51,12 @@ Here we'll go more in depth of how you can use Apollo's Form component to the fo
 ### `client` Form
 
 The client-side form is probably the most familiar type of form in its implementation if you have
-previous experience dealing with validation in React. At this point you're probably thinking: "ugh,
-these guys probably added extra steps to creating a form by making me use their wrapper, right?"
+previous experience dealing with validation in React. At this point you're probably thinking: *ugh,
+these guys probably added extra steps to creating a form by making me use their wrapper, right?*
 **Wrong!** We took the time to abstract the user from any painful state declarations and arbitrary
-form setup by handling that logic ourselves under the hood.
+form setup by handling that logic ourselves under the hood. On top of that, this form is also wicked
+performant. Only ever re-renders when there is an error or a submission. Cool right? We have
+`react-hook-form` to thank for that.
 
 #### Submission & Failure
 
@@ -118,17 +130,15 @@ export type FormErrorHandler = (errors: FormErrors) => void;
 
 #### Basic Implementation
 
-If you want to create a form and keep see the values, just put the inputs you want from Apollo, 
-and we'll track the changes magically without you worrying about the rest. Here we'll show you all 
+If you want to create a form and keep see the values, just put the inputs you want from Apollo,
+and we'll track the changes magically without you worrying about the rest. Here we'll show you all
 the inputs in one form and when you submit, you should see all the submit data.
 
 > **Fair warning:** This component will throw if you try to use inputs that don't give them names,
 > it's kind of important that you do so that we can register them in our Form :)
 
 <Canvas>
-    <Story name="Basic Form">
-        {BasicForm.bind({})}
-    </Story>
+    <Story name="Basic Form">{BasicForm.bind({})}</Story>
 </Canvas>
 
 #### Validation
@@ -164,35 +174,46 @@ the function in the `validator` prop of the component you want to validate, and 
 > `validator` function due to accessibility concerns.
 
 <Canvas>
-    <Story name="Validated Form">
-        {ValidatedForm.bind({})}
+    <Story name="Validated Form">{ValidatedForm.bind({})}</Story>
+</Canvas>
+
+#### Adding `actionData`
+
+_That's great and all, but what if I need client-side validation for my Remix app?_ - you might be
+asking. We got you covered! All you have to do is add the `actionData` to the `actionData` prop on
+the form and that's it. Nothing much else to it.
+
+This will:
+
+-   disable `preventDefault()` and other `react-hook-form` submission functionality
+-   populate any `field` data on the spot
+-   validate any error pertaining to a specific field using the `fieldErrors` section of the
+    `actionData`
+-   refresh errors on input
+
+In the example below, we are using the following validator to show this example:
+
+```typescript
+const userNameValidator: FormValidator = (data) => {
+    if (data.text === 'john-cena') return 'You cannot just leave this blank (get it?)';
+    return null;
+};
+```
+
+<Canvas>
+    <Story name="Client Side Remix Form" args={{ actionData: clientActionData }}>
+        {ClientSideRemixForm.bind({})}
     </Story>
 </Canvas>
 
 ### `remix` Form
 
-The `remix` form is pretty much your standard form with a few extra features. It's built on top of
-the `ActionData` object you would provide for your typical `remix` validation route. The nice thing
-about this form is that it will automatically display any errors or default values for you as shown
-in the example below.
-
-Given we have this `ActionData` object:
-
-```typescript
-const actionData: ActionData = {
-    fields: {
-        username: 'john-cena',
-        password: 'youcantseeme',
-        rating: '1',
-        options: ['1', '2'],
-        radio: true,
-        checkbox: true,
-        switch: true,
-    },
-};
-```
-
-We can use the `remix` form like this:
+You might be asking right now - *Why is there a remix form if I can just use the client-side form?*
+It's because of overhead. The client-side form, while it has a ton of functionality, there is still
+some overhead created by just mounting the `react-hook-form`, plus you have to consider that there
+is a form re-render everytime an error occurs in one of the inputs. If you don't want any
+re-rendering, ever, and just need the server-side validation, the `remix` form is for you. Just
+put the `actionData` where it belongs, and you're good to go.
 
 <Canvas>
     <Story

--- a/stories/Group.stories.mdx
+++ b/stories/Group.stories.mdx
@@ -25,6 +25,7 @@ You might benefit from checking out the documentation for those components:
     -   [Describing the Group](#describing-the-group)
     -   [Radios & Checkboxes](#radios--checkboxes)
         -   [Basic Layout](#basic-layout)
+        -   [Default Values](#default-values)
     -   [onChange](#onchange)
     -   [Props Applicable to All](#props-applicable-to-all)
     -   [Its use in the Form](#its-use-in-the-form)
@@ -82,6 +83,20 @@ by side? Just add the `inline` prop and you can accomplish that effect!
 
 <Canvas>
     <Story name="Inline Groups" args={{ label: 'Radios', inline: true }}>
+        {RadioGroup.bind({})}
+    </Story>
+</Canvas>
+
+#### Default Values
+
+We wanted the `Group` to be especially easy to use with default values, so we added the `defaultValue`
+prop. This prop can either be a string or an array of strings. If you register a string as the default
+value, the component will automatically select the corresponding `Radio`. If you register an array of
+strings, the component will automatically select the corresponding `Checkbox` components. Simple right?
+Here's an example:
+
+<Canvas>
+    <Story name="Default Values" args={{ label: 'Radios', defaultValue: '1' }}>
         {RadioGroup.bind({})}
     </Story>
 </Canvas>

--- a/stories/examples/ErrorMessage.tsx
+++ b/stories/examples/ErrorMessage.tsx
@@ -14,7 +14,7 @@ export const ProperUseOfErrorMessage: SampleStory = (args) => {
             <Divider />
             <Text>Click it</Text>
             <br />
-            <Button onClick={() => setActive(!active)} aria-errorMessage="click-error">
+            <Button onClick={() => setActive(!active)} aria-errormessage="click-error">
                 Click me :)
             </Button>
             <ErrorMessage {...args} id="click-error" active={args.active || active}>

--- a/stories/examples/Form.tsx
+++ b/stories/examples/Form.tsx
@@ -1,6 +1,39 @@
 import React from 'react';
 import type { SampleStory } from './util';
-import { Form, Group, TextInput, Radio, Checkbox, Button, Switch } from '../../src';
+import {
+    Form,
+    Group,
+    TextInput,
+    Radio,
+    Checkbox,
+    Button,
+    Switch,
+    FormActionData,
+    Text,
+    FormValidator,
+} from '../../src';
+
+export const clientActionData: FormActionData = {
+    fields: {
+        username: 'john-cen',
+        password: 'youcantseeme',
+        rating: '1',
+        options: ['1'],
+        radio: true,
+        checkbox: true,
+        switch: true,
+    },
+    fieldErrors: {
+        // username: 'You cannot just leave this blank (get it?)',
+        checkbox: 'sup',
+        options: 'sup',
+    },
+};
+
+const userNameValidator: FormValidator = (data) => {
+    if (data.text === 'john-cena') return 'You cannot just leave this blank (get it?)';
+    return null;
+};
 
 export const BasicForm: SampleStory = (args) => {
     const onSubmit = (data): void => {
@@ -15,35 +48,30 @@ export const BasicForm: SampleStory = (args) => {
     };
 
     return (
-        <Form onSubmit={onSubmit}>
-            <Group
-                type="organization"
-                label="Basic Form"
-                hint="Just showcasing our inputs for you :)"
-            >
-                <TextInput
-                    label="Plain old Text Input"
-                    name="text-input"
-                    placeholder="Type stuff in me :)"
-                />
-                <Group label="Plain old Radios" name="radios">
-                    <Radio value="radio 1">Radio 1</Radio>
-                    <Radio value="radio 2">Radio 2</Radio>
-                </Group>
-                <Group label="Plain old Checkboxes" name="checkboxes">
-                    <Checkbox value="checkbox 1">Checkbox 1</Checkbox>
-                    <Checkbox value="checkbox 2">Checkbox 2</Checkbox>
-                </Group>
-                <Radio id="radio" value="lone radio">
-                    Plain old Radio
-                </Radio>
-                <Checkbox id="checkbox" name="checkbox" value="lone checkbox">
-                    Plain old Checkbox
-                </Checkbox>
-                <Switch name="switch" value="lone switch">
-                    Plain old Switch
-                </Switch>
+        <Form onSubmit={onSubmit} action="fasdfas">
+            <TextInput
+                required
+                label="Plain old Text Input"
+                name="text-input"
+                placeholder="Type stuff in me :)"
+            />
+            <Group label="Plain old Radios" name="radios">
+                <Radio value="radio 1">Radio 1</Radio>
+                <Radio value="radio 2">Radio 2</Radio>
             </Group>
+            <Group label="Plain old Checkboxes" name="checkboxes">
+                <Checkbox value="checkbox 1">Checkbox 1</Checkbox>
+                <Checkbox value="checkbox 2">Checkbox 2</Checkbox>
+            </Group>
+            <Radio id="radio" value="lone radio">
+                Plain old Radio
+            </Radio>
+            <Checkbox id="checkbox" name="checkbox" value="lone checkbox">
+                Plain old Checkbox
+            </Checkbox>
+            <Switch name="switch" value="lone switch">
+                Plain old Switch
+            </Switch>
             <Button>Submit</Button>
         </Form>
     );
@@ -64,11 +92,41 @@ export const ValidatedForm: SampleStory = (args) => {
                 validator={(input) =>
                     input?.text.length < 5 && 'Text input must be at least 5 characters long'
                 }
+                required
                 name="password"
                 label="Password"
                 hint="must be at least 5 characters"
                 password
             />
+            <Button>Submit</Button>
+        </Form>
+    );
+};
+
+export const ClientSideRemixForm: SampleStory = (args) => {
+    return (
+        <Form {...args}>
+            <TextInput validator={userNameValidator} required label="Username" name="username" />
+            <TextInput label="Password" name="password" password />
+            <Group name="rating" label="Rating" inline>
+                <Radio value="1">1</Radio>
+                <Radio value="2">2</Radio>
+                <Radio value="3">3</Radio>
+            </Group>
+            <Group name="options" label="Options" inline>
+                <Checkbox value="1">1</Checkbox>
+                <Checkbox value="2">2</Checkbox>
+                <Checkbox value="3">3</Checkbox>
+            </Group>
+            <Radio id="radio" name="radio" value="radio">
+                Radio
+            </Radio>
+            <Checkbox id="checkbox" name="checkbox" value="checkbox">
+                Checkbox
+            </Checkbox>
+            <Switch id="switch" name="switch">
+                Switch
+            </Switch>
             <Button>Submit</Button>
         </Form>
     );

--- a/stories/examples/Group.tsx
+++ b/stories/examples/Group.tsx
@@ -3,16 +3,14 @@ import type { SampleStory } from './util';
 import { Group, Radio, Checkbox, Form, Button, FormActionData } from '../../src';
 
 export const RadioGroup: SampleStory = (args) => (
-    <Group {...args} onChange={(data) => window.alert(`Radio ${data?.target.value}: checked`)}>
-        <Radio name="radio" value="1">
-            Option 1
-        </Radio>
-        <Radio name="radio" value="2">
-            Option 2
-        </Radio>
-        <Radio name="radio" value="3">
-            Option 3
-        </Radio>
+    <Group
+        {...args}
+        name="radio"
+        onChange={(data) => window.alert(`Radio ${data?.target.value}: checked`)}
+    >
+        <Radio value="1">Option 1</Radio>
+        <Radio value="2">Option 2</Radio>
+        <Radio value="3">Option 3</Radio>
     </Group>
 );
 

--- a/test/ErrorMessage.test.tsx
+++ b/test/ErrorMessage.test.tsx
@@ -22,7 +22,7 @@ describe('ErrorMessage', () => {
                 <Divider />
                 <Text>Click it</Text>
                 <br />
-                <Button aria-errorMessage="click-error">Click me :)</Button>
+                <Button aria-errormessage="click-error">Click me :)</Button>
                 <ErrorMessage id="click-error">Nothing Happened :/</ErrorMessage>
             </Card>
         );
@@ -32,7 +32,7 @@ describe('ErrorMessage', () => {
                 <Divider />
                 <Text>Click it</Text>
                 <br />
-                <Button aria-errorMessage="click-error">Click me :)</Button>
+                <Button aria-errormessage="click-error">Click me :)</Button>
                 <ErrorMessage id="click-error" active>
                     Nothing Happened :/
                 </ErrorMessage>

--- a/test/Form.test.tsx
+++ b/test/Form.test.tsx
@@ -33,6 +33,27 @@ const checkboxValidator: FormValidator = (data) => {
     return (data?.checkbox?.length || 0) < 2 ? groupError : null;
 };
 
+const validActionData: FormActionData = {
+    fields: {
+        input: 'input',
+        radioGroup: 'option-1',
+        checkboxGroup: ['checkbox-1', 'checkbox-2'],
+        checkbox: true,
+        radio: true,
+        switch: true,
+    },
+};
+
+const invalidActionData: FormActionData = {
+    fieldErrors: {
+        input: 'failed',
+        radioGroup: 'failed',
+        checkboxGroup: 'failed',
+        checkbox: 'failed',
+        radio: 'failed',
+    },
+};
+
 describe('Client Side Form', () => {
     it('complies with WCAG', async () => {
         // given
@@ -88,7 +109,63 @@ describe('Client Side Form', () => {
         results.forEach((result: any) => expect(result).toHaveNoViolations());
     });
 
-    it('will submit when there are no requirement', async () => {
+    it('displays all default values correctly', () => {
+        // given
+        render(
+            <Form>
+                <Group
+                    name="radioGroup"
+                    label="options"
+                    defaultValue={validActionData?.fields?.radioGroup}
+                >
+                    <Radio value="option-1">Option 1</Radio>
+                    <Radio value="option-2">Option 2</Radio>
+                </Group>
+                <Group
+                    name="checkboxGroup"
+                    label="checkboxes"
+                    defaultValue={validActionData?.fields?.checkboxGroup}
+                >
+                    <Checkbox value="checkbox-1">Checkbox 1</Checkbox>
+                    <Checkbox value="checkbox-2">Checkbox 2</Checkbox>
+                </Group>
+                <Checkbox
+                    id="checkbox"
+                    value="checkbox"
+                    defaultChecked={validActionData?.fields?.checkbox}
+                >
+                    Checkbox single
+                </Checkbox>
+                <Radio id="radio" value="radio" defaultChecked={validActionData?.fields?.radio}>
+                    Radio single
+                </Radio>
+                <TextInput
+                    label="input"
+                    name="input"
+                    defaultValue={validActionData?.fields?.input}
+                />
+                <Switch
+                    name="switch"
+                    value="switch-1"
+                    defaultChecked={validActionData?.fields?.switch}
+                >
+                    Switch
+                </Switch>
+            </Form>
+        );
+
+        // when then
+        expect(screen.getByDisplayValue(/input/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/option 1/i)).toBeChecked();
+        expect(screen.getByLabelText(/option 2/i)).not.toBeChecked();
+        expect(screen.getByLabelText(/checkbox 1/i)).toBeChecked();
+        expect(screen.getByLabelText(/checkbox 2/i)).toBeChecked();
+        expect(screen.getByLabelText(/checkbox single/i)).toBeChecked();
+        expect(screen.getByLabelText(/radio single/i)).toBeChecked();
+        expect(screen.getByLabelText(/switch/i)).toBeChecked();
+    });
+
+    it('will submit when there are no requirements', async () => {
         // given
         const onSubmit: jest.Mock<any, any> = jest.fn();
         const username = 'username';
@@ -117,7 +194,7 @@ describe('Client Side Form', () => {
         expect(onSubmit).toBeCalledWith(expect.objectContaining(expected), expect.anything());
     });
 
-    it('it will not submit if form has missing required fields', async () => {
+    it('will not submit if form has missing required fields', async () => {
         // given
         const onError: jest.Mock<any, any> = jest.fn();
         const onSubmit: jest.Mock<any, any> = jest.fn();
@@ -144,6 +221,151 @@ describe('Client Side Form', () => {
 
         // when
         await act(async () => {
+            userEvent.click(screen.getByText(/submit/i));
+        });
+
+        // then
+        expect(onSubmit).not.toHaveBeenCalled();
+        expect(onError).toHaveBeenCalledWith(expect.objectContaining(expected), expect.anything());
+    });
+
+    it('will not submit there are missing required fields with actionData', async () => {
+        // given
+        const onError: jest.Mock<any, any> = jest.fn();
+        const onSubmit: jest.Mock<any, any> = jest.fn();
+        const expected = {
+            password: {
+                message: 'label is required.',
+                ref: expect.anything(),
+                type: 'required',
+            },
+            username: {
+                message: 'label is required.',
+                ref: expect.anything(),
+                type: 'required',
+            },
+        };
+
+        render(
+            <Form onSubmit={onSubmit} onError={onError} actionData={{ fields: {} }} type="client">
+                <TextInput label="label" required name="username" placeholder="UserName" />
+                <TextInput label="label" required name="password" placeholder="password" password />
+                <Button>Submit</Button>
+            </Form>
+        );
+
+        // when
+        await act(async () => {
+            onError(expect.objectContaining(expected), expect.anything());
+        });
+
+        // then
+        expect(onSubmit).not.toHaveBeenCalled();
+        expect(onError).toHaveBeenCalledWith(expect.objectContaining(expected), expect.anything());
+    });
+
+    it('will not submit if an input is required and the user removes all the text', async () => {
+        // given
+        const onError: jest.Mock<any, any> = jest.fn();
+        const onSubmit: jest.Mock<any, any> = jest.fn();
+        const expected = {
+            password: {
+                message: 'label is required.',
+                ref: expect.anything(),
+                type: 'validator', // this is because the validator catches cleared requirements
+            },
+        };
+
+        render(
+            <Form onSubmit={onSubmit} onError={onError} type="client">
+                <TextInput
+                    label="label"
+                    required
+                    name="password"
+                    placeholder="password"
+                    password
+                    defaultValue="something"
+                />
+                <Button>Submit</Button>
+            </Form>
+        );
+
+        // when
+        await act(async () => {
+            userEvent.clear(screen.getByPlaceholderText(/password/i));
+            userEvent.click(screen.getByText(/submit/i));
+        });
+
+        // then
+        expect(onSubmit).not.toHaveBeenCalled();
+        expect(onError).toHaveBeenCalledWith(expect.objectContaining(expected), expect.anything());
+    });
+
+    it('will show error if input is required and user clears all action data text ', () => {
+        // given
+        const actionData = {
+            fields: {
+                password: 'password',
+            },
+        };
+
+        render(
+            <Form actionData={actionData}>
+                <TextInput
+                    label="Password"
+                    required
+                    name="password"
+                    placeholder="password"
+                    password
+                />
+                <Button>Submit</Button>
+            </Form>
+        );
+
+        // when
+        userEvent.clear(screen.getByLabelText(/password/i));
+
+        // then
+        expect(screen.getByText(/password is required/i)).toBeInTheDocument();
+    });
+
+    it('will not submit if text input with match property does not match', async () => {
+        // given
+        const onError: jest.Mock<any, any> = jest.fn();
+        const onSubmit: jest.Mock<any, any> = jest.fn();
+        const expected = {
+            confirmPassword: {
+                message: 'Passwords do not match.',
+                ref: expect.anything(),
+                type: 'validator',
+            },
+        };
+
+        render(
+            <Form onSubmit={onSubmit} onError={onError} type="client">
+                <TextInput
+                    label="Password"
+                    required
+                    name="password"
+                    placeholder="password OG"
+                    password
+                    match="password"
+                />
+                <TextInput
+                    label="Confirm Password"
+                    name="confirmPassword"
+                    placeholder="confirm password"
+                    password
+                    match="password"
+                    matchMessage="Passwords do not match."
+                />
+                <Button>Submit</Button>
+            </Form>
+        );
+
+        // when
+        await act(async () => {
+            userEvent.type(screen.getByPlaceholderText(/password og/i), 'password');
             userEvent.click(screen.getByText(/submit/i));
         });
 
@@ -223,6 +445,49 @@ describe('Client Side Form', () => {
         // then
         expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining(expected), expect.anything());
         expect(onError).not.toHaveBeenCalledWith();
+    });
+
+    it('will submit if input matches the text its supposed to match', async () => {
+        // given
+        const onSubmit: jest.Mock<any, any> = jest.fn();
+        const onError: jest.Mock<any, any> = jest.fn();
+        const password = 'password';
+        const expected = {
+            password: { text: password },
+            'match password': { text: password },
+        };
+
+        render(
+            <Form onSubmit={onSubmit} onError={onError}>
+                <TextInput
+                    label="label"
+                    required
+                    name="password"
+                    placeholder="password og"
+                    password
+                />
+                <TextInput
+                    label="match"
+                    required
+                    name="match password"
+                    placeholder="match password"
+                    password
+                    match="password"
+                />
+                <Button>Submit</Button>
+            </Form>
+        );
+
+        // when
+        await act(async () => {
+            userEvent.type(screen.getByPlaceholderText(/password og/i), password);
+            userEvent.type(screen.getByPlaceholderText(/match password/i), password);
+            userEvent.click(screen.getByText(/submit/i));
+        });
+
+        // then expect
+        expect(onError).not.toHaveBeenCalled();
+        expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining(expected), expect.anything());
     });
 
     it('will retain the text input on change callback', () => {
@@ -389,28 +654,92 @@ describe('Client Side Form', () => {
         expect(onError).toHaveBeenCalledWith(expect.objectContaining(expected), expect.anything());
         expect(onSubmit).not.toHaveBeenCalled();
     });
+
+    it('will not submit form when a submission method is provided', () => {
+        // given
+        const event = new Event('submit');
+        event.preventDefault = jest.fn();
+        render(
+            <Form method="POST" action="https://example.com">
+                <TextInput label="label" required name="password" placeholder="password" />
+                <Button>Submit</Button>
+            </Form>
+        );
+
+        // when
+        const form = screen.getByRole('textbox').parentElement?.parentElement;
+        if (!form) throw new Error("Couldn't find form");
+        form.dispatchEvent(event);
+
+        // then
+        expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('displays all action data values correctly', () => {
+        // given
+        render(
+            <Form actionData={validActionData}>
+                <Group name="radioGroup" label="options">
+                    <Radio value="option-1">Option 1</Radio>
+                    <Radio value="option-2">Option 2</Radio>
+                </Group>
+                <Group name="checkboxGroup" label="checkboxes">
+                    <Checkbox value="checkbox-1">Checkbox 1</Checkbox>
+                    <Checkbox value="checkbox-2">Checkbox 2</Checkbox>
+                </Group>
+                <Checkbox id="checkbox" value="checkbox">
+                    Checkbox single
+                </Checkbox>
+                <Radio id="radio" value="radio">
+                    Radio single
+                </Radio>
+                <TextInput label="input" name="input" />
+                <Switch name="switch" value="switch-1">
+                    Switch
+                </Switch>
+            </Form>
+        );
+
+        // when then
+        expect(screen.getByDisplayValue(/input/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/option 1/i)).toBeChecked();
+        expect(screen.getByLabelText(/option 2/i)).not.toBeChecked();
+        expect(screen.getByLabelText(/checkbox 1/i)).toBeChecked();
+        expect(screen.getByLabelText(/checkbox 2/i)).toBeChecked();
+        expect(screen.getByLabelText(/checkbox single/i)).toBeChecked();
+        expect(screen.getByLabelText(/radio single/i)).toBeChecked();
+        expect(screen.getByLabelText(/switch/i)).toBeChecked();
+    });
+
+    it('renders error messages when invalid', () => {
+        // given
+        render(
+            <Form type="remix" actionData={invalidActionData}>
+                <Group name="radioGroup" label="options">
+                    <Radio value="option-1">Option 1</Radio>
+                    <Radio value="option-2">Option 2</Radio>
+                </Group>
+                <Group name="checkboxGroup" label="checkboxes">
+                    <Checkbox value="checkbox-1">Checkbox 1</Checkbox>
+                    <Checkbox value="checkbox-2">Checkbox 2</Checkbox>
+                </Group>
+                <Checkbox id="checkbox" value="checkbox">
+                    Checkbox
+                </Checkbox>
+                <Radio id="radio" value="radio">
+                    Option
+                </Radio>
+                <TextInput label="input" name="input" />
+                <Switch name="switch" value="switch">
+                    Switch
+                </Switch>
+            </Form>
+        );
+
+        // when then
+        expect(screen.queryAllByText(/failed/i)).toHaveLength(5);
+    });
 });
-
-const validActionData: FormActionData = {
-    fields: {
-        input: 'input',
-        radioGroup: 'option-1',
-        checkboxGroup: ['checkbox-1', 'checkbox-2'],
-        checkbox: true,
-        radio: true,
-        switch: true,
-    },
-};
-
-const invalidActionData: FormActionData = {
-    fieldErrors: {
-        input: 'failed',
-        radioGroup: 'failed',
-        checkboxGroup: 'failed',
-        checkbox: 'failed',
-        radio: 'failed',
-    },
-};
 
 describe('Server Side Form', () => {
     it('complies with WCAG 2.0', async () => {

--- a/test/Group.test.tsx
+++ b/test/Group.test.tsx
@@ -10,19 +10,19 @@ describe('Group', () => {
     it('complies with WCAG', async () => {
         // given
         const { container: validGroup } = render(
-            <Group label="something">
+            <Group name="something" label="something">
                 <Radio value="something">something</Radio>
             </Group>
         );
 
         const { container: validGroupWithHint } = render(
-            <Group label="something" hint="hint">
+            <Group name="something" label="something" hint="hint">
                 <Radio value="something">something</Radio>
             </Group>
         );
 
         const { container: invalidGroup } = render(
-            <Group label="something" invalid>
+            <Group name="something" label="something" invalid>
                 <Radio value="something">something</Radio>
             </Group>
         );
@@ -254,5 +254,29 @@ describe('Group', () => {
 
         // then
         expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('will render default values of radios and checkboxes', () => {
+        // given
+        const groupValue: string[] = ['value 1', 'value 2'];
+        const groupValue2 = 'value 3';
+        render(
+            <>
+                <Group label="label" name="group" defaultValue={groupValue}>
+                    <Checkbox value="value 1">Option 1</Checkbox>
+                    <Checkbox value="value 2">Option 2</Checkbox>
+                </Group>
+                <Group label="label" name="group" defaultValue={groupValue2}>
+                    <Radio value="value 3">Option 3</Radio>
+                    <Radio value="value 4">Option 4</Radio>
+                </Group>
+            </>
+        );
+
+        // when then
+        expect(screen.getByLabelText(/option 1/i)).toBeChecked();
+        expect(screen.getByLabelText(/option 2/i)).toBeChecked();
+        expect(screen.getByLabelText(/option 3/i)).toBeChecked();
+        expect(screen.getByLabelText(/option 4/i)).not.toBeChecked();
     });
 });


### PR DESCRIPTION
# Extending Hybrid Features to the Client Form
In this PR I am extending the `actionData` object for server-side validation purposes to the Client Side form. This will enable 
- https://linear.app/milemarker10/issue/MIL-636/feature-creating-a-hybrid-form

## Purpose
The purpose of this PR is to ensure that the form is funtionally available for its use in Leto. This ensures that the user can give the client form action data with default values, as well as give them the option to have startup validation followed by client-side validation.

## Summary of Changes
Files changed in this PR goes as follows:
- `Form/overload`:
  - Changed all inputs to accept a `defaultValue` and allowed it so that the `actionData` could serve as that `defaultValue` when provided to the form.
  - Form now extends `HTMLProps` rather than `HTMLAttributes` so that it can retain all of the forms natural properties. This means that `method` and `action` are now supported by default.
- `Group`: Now accepts a default value that will influence all the inputs

Added new types as well to improve quality of life in general Apollo development. Now the `Overload` file is a different beast with the following new properties:
- Interface: for components who optionally use `parentProps`
- ParentProps: official type for pass through props via `Overload` and `Interface` type components
- RenderAll: standardized type for functions used to repeat parent formatting

# Certificate
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.