### PR TITLE
Added Error Message Component

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes, ReactNode, FC, CSSProperties, useEffect } from 'react';
+import { HTMLAttributes, ReactNode, FC, useEffect } from 'react';
 import React from 'react';
 import './Checkbox.css';
 
@@ -6,6 +6,7 @@ import type { Apollo } from '../../interfaces/Apollo';
 import { gaurdApolloName } from '../../util/ErrorHandling';
 
 import { Text } from '../Text/Text';
+import { ErrorMessage } from '../ErrorMessage/ErrorMessage';
 
 export interface ICheckbox extends HTMLAttributes<HTMLInputElement>, Apollo<'Checkbox'> {
     /** String that identifies the checkbox */
@@ -43,6 +44,7 @@ export const Checkbox: FC<ICheckbox> = ({
     className,
     invalid,
     required,
+    value,
     errorMessage,
     ...props
 }) => {
@@ -67,6 +69,7 @@ export const Checkbox: FC<ICheckbox> = ({
                 <input
                     {...props}
                     id={id}
+                    value={value}
                     aria-required={required}
                     aria-invalid={invalid}
                     aria-errormessage={id ? `${id}-error` : undefined}
@@ -88,20 +91,14 @@ export const Checkbox: FC<ICheckbox> = ({
                 </Text>
             </label>
             {invalid && errorMessage && inline ? <br /> : null}
-            {invalid && errorMessage ? (
-                <div role="alert" id={id ? `${id}-error` : undefined}>
-                    <Text color="#c90000" style={errorTextStyle}>
-                        {errorMessage}
-                    </Text>
-                </div>
-            ) : null}
+            <ErrorMessage
+                id={id ? `${id}-error` : `${value}-error`}
+                active={Boolean(invalid && errorMessage)}
+            >
+                {errorMessage}
+            </ErrorMessage>
         </>
     );
 };
 
 Checkbox.defaultProps = { 'data-apollo': 'Checkbox' };
-
-const errorTextStyle: CSSProperties = {
-    paddingTop: 5,
-    paddingBottom: 10,
-};

--- a/src/components/ErrorMessage/ErrorMessage.css
+++ b/src/components/ErrorMessage/ErrorMessage.css
@@ -1,0 +1,3 @@
+div[data-apollo="ErrorMessage"] {
+    padding-top: 5px;
+}

--- a/src/components/ErrorMessage/ErrorMessage.tsx
+++ b/src/components/ErrorMessage/ErrorMessage.tsx
@@ -1,0 +1,43 @@
+import type { FC, HTMLAttributes, ReactNode } from 'react';
+import React from 'react';
+import './ErrorMessage.css';
+
+import type { Apollo } from '../../interfaces/Apollo';
+
+import { Text } from '../Text/Text';
+import { gaurdApolloName } from '../../util/ErrorHandling';
+
+export interface IErrorMessage extends HTMLAttributes<HTMLDivElement>, Apollo<'ErrorMessage'> {
+    /** Error message id */
+    id: string;
+    /** Must have an error message */
+    children: ReactNode;
+    /** Determines whether the error message is active */
+    active?: boolean;
+}
+
+/**
+ * Apollo's error message component, used to display error messages
+ *
+ * @return error message components
+ */
+export const ErrorMessage: FC<IErrorMessage> = ({
+    'data-apollo': dataApollo = 'ErrorMessage',
+    active = false,
+    className = '',
+    children,
+    ...props
+}) => {
+    gaurdApolloName({ 'data-apollo': dataApollo }, 'ErrorMessage');
+
+    return active ? (
+        <div
+            {...props}
+            role="alert"
+            data-apollo={dataApollo}
+            className={`apollo-component-library-error-message-component ${className}`}
+        >
+            <Text color="#c90000">{children}</Text>
+        </div>
+    ) : null;
+};

--- a/src/components/Group/Group.tsx
+++ b/src/components/Group/Group.tsx
@@ -8,6 +8,7 @@ import { gaurdApolloName } from '../../util/ErrorHandling';
 import FormatChildren from '../../util/FormatChildren';
 
 import { Text } from '../Text/Text';
+import { ErrorMessage } from '../ErrorMessage/ErrorMessage';
 import Radio from './overload/Radio';
 import Checkbox from './overload/Checkbox';
 import View from './overload/View';
@@ -135,13 +136,9 @@ export const Group: FC<IGroup> = ({
                 >
                     {renderAll(children)}
                 </div>
-                {invalid && errorMessage ? (
-                    <div role="alert" id={name ? `${name}-error` : undefined}>
-                        <Text color="#c90000" style={errorTextStyle}>
-                            {errorMessage}
-                        </Text>
-                    </div>
-                ) : null}
+                <ErrorMessage id={`${name}-error`} active={Boolean(invalid && errorMessage)}>
+                    {errorMessage}
+                </ErrorMessage>
             </fieldset>
         </>
     );
@@ -165,8 +162,4 @@ const getHintTextStyle = (type: string): CSSProperties => {
         paddingBottom: 5,
         marginTop: 0,
     };
-};
-
-const errorTextStyle: CSSProperties = {
-    paddingTop: 5,
 };

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes, ReactNode, FC, useEffect, CSSProperties } from 'react';
+import { HTMLAttributes, ReactNode, FC, useEffect } from 'react';
 import React from 'react';
 import './Radio.css';
 
@@ -6,6 +6,7 @@ import type { Apollo } from '../../interfaces/Apollo';
 import { gaurdApolloName } from '../../util/ErrorHandling';
 
 import { Text } from '../Text/Text';
+import { ErrorMessage } from '../ErrorMessage/ErrorMessage';
 
 export interface IRadio extends HTMLAttributes<HTMLInputElement>, Apollo<'Radio'> {
     /** String that identifies the radio */
@@ -41,6 +42,7 @@ export const Radio: FC<IRadio> = ({
     children,
     className,
     invalid,
+    value,
     required,
     errorMessage,
     id,
@@ -67,9 +69,10 @@ export const Radio: FC<IRadio> = ({
                 <input
                     {...props}
                     id={id}
+                    value={value}
                     aria-required={required}
                     aria-invalid={invalid}
-                    aria-errormessage={id ? `${id}-error` : undefined}
+                    aria-errormessage={id ? `${id}-error` : `${value}-error`}
                     type="radio"
                     className={`
                         apollo-component-library-radio-component 
@@ -87,20 +90,14 @@ export const Radio: FC<IRadio> = ({
                 </Text>
             </label>
             {invalid && errorMessage && inline ? <br /> : null}
-            {invalid && errorMessage ? (
-                <div role="alert" id={id ? `${id}-error` : undefined}>
-                    <Text color="#c90000" style={errorTextStyle}>
-                        {errorMessage}
-                    </Text>
-                </div>
-            ) : null}
+            <ErrorMessage
+                id={id ? `${id}-error` : `${value}-error`}
+                active={Boolean(invalid && errorMessage)}
+            >
+                {errorMessage}
+            </ErrorMessage>
         </>
     );
 };
 
 Radio.defaultProps = { 'data-apollo': 'Radio' };
-
-const errorTextStyle: CSSProperties = {
-    paddingTop: 5,
-    paddingBottom: 10,
-};

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -7,6 +7,7 @@ import type { FormTextData, FormValidator, StyleVariant } from '../../interfaces
 import { gaurdApolloName } from '../../util/ErrorHandling';
 
 import { Text } from '../Text/Text';
+import { ErrorMessage } from '../ErrorMessage/ErrorMessage';
 
 export interface ITextInput extends HTMLAttributes<HTMLInputElement>, Apollo<'TextInput'> {
     /** To comply with WCAG 2.0, all inputs **must** have labels */
@@ -79,7 +80,7 @@ export const TextInput: FC<ITextInput> = ({
                     name={name}
                     aria-required={required}
                     aria-invalid={invalid}
-                    aria-errormessage={name ? `${name}-error` : undefined}
+                    aria-errormessage={name ? `${name}-error` : `${label}-error`}
                     type={password ? 'password' : 'text'}
                     className={`apollo-component-library-text-input 
                         ${variant} 
@@ -88,13 +89,12 @@ export const TextInput: FC<ITextInput> = ({
                     `}
                 />
             </label>
-            {invalid && errorMessage ? (
-                <div role="alert" id={name ? `${name}-error` : undefined}>
-                    <Text color="#c90000" style={errorTextStyle}>
-                        {errorMessage}
-                    </Text>
-                </div>
-            ) : null}
+            <ErrorMessage
+                id={name ? `${name}-error` : `${label}-error`}
+                active={Boolean(invalid && errorMessage)}
+            >
+                {errorMessage}
+            </ErrorMessage>
         </div>
     );
 };
@@ -108,8 +108,4 @@ const labelTextStyle: CSSProperties = {
 const hintTextStyle: CSSProperties = {
     fontSize: '0.9rem',
     paddingBottom: 5,
-};
-
-const errorTextStyle: CSSProperties = {
-    paddingTop: 5,
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,6 +24,7 @@ export { NavigationBar } from './components/NavigationBar/NavigationBar';
 export { Section } from './components/Section/Section';
 export { Table } from './components/Table/Table';
 export { Menu } from './components/Menu/Menu';
+export { ErrorMessage } from './components/ErrorMessage/ErrorMessage';
 
 export type {
     FormValidator,

--- a/stories/ErrorMessage.stories.mdx
+++ b/stories/ErrorMessage.stories.mdx
@@ -1,0 +1,56 @@
+import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs';
+import { linkTo } from '@storybook/addon-links';
+
+import { ErrorMessage } from '../src';
+
+import { StandaloneError, ProperUseOfErrorMessage } from './examples/ErrorMessage';
+
+<Meta title="Layout/Error Message" component={ErrorMessage} />
+
+# Error Message
+
+This component's sole purpose in Apollo is to display error messages to the user.
+
+## Table of Contents
+
+-   [Functionality](#functionality)
+-   [Setup](#setup)
+-   [Other Props & Functionalities](#other-props--functionalities)
+
+## Functionality
+
+The `ErrorMessage` is a very simple component to use. It's only intended to be used as a means of
+displaying errors in an accessible, and uniform way in compliance to Apollo standards. To use it
+you simply pass the message through the component's tags and set the `active` prop to `true` and
+you will be able to see it.
+
+<Canvas>
+    <Story
+        name="Standalone Error"
+        args={{ id: 'error-message', active: true, children: 'I am an error' }}
+    >
+        {StandaloneError.bind({})}
+    </Story>
+</Canvas>
+
+## Setup
+
+In the case you want to use the `ErrorMessage`, make sure that the element the error is being 
+displayed for has its `aria-errorMessage` prop set to the `id` of this component. This will tell
+the user where the error came from.
+
+<Canvas>
+    <Story
+        name="Proper use of Error Messages"
+        args={{ id: 'error-message', active: true, children: 'I a loading error' }}
+    >
+        {ProperUseOfErrorMessage.bind({})}
+    </Story>
+</Canvas>
+
+## Other Props & Functionalities
+
+All properties were covered during the explanation of this property, but for a full list of props
+you can see the props table below:
+
+<ArgsTable of={ErrorMessage} />

--- a/stories/examples/ErrorMessage.tsx
+++ b/stories/examples/ErrorMessage.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+import type { SampleStory } from './util';
+import { ErrorMessage, Card, Text, Divider, Button } from '../../src';
+
+// the name of this function should be the name of the story in the docs
+export const StandaloneError: SampleStory = (args) => <ErrorMessage {...args} />;
+
+export const ProperUseOfErrorMessage: SampleStory = (args) => {
+    const [active, setActive] = useState(false);
+
+    return (
+        <Card>
+            <Text header={3}>Something will happen if you click the button!</Text>
+            <Divider />
+            <Text>Click it</Text>
+            <br />
+            <Button onClick={() => setActive(!active)} aria-errorMessage="click-error">
+                Click me :)
+            </Button>
+            <ErrorMessage {...args} id="click-error" active={args.active || active}>
+                Nothing Happened :/
+            </ErrorMessage>
+        </Card>
+    );
+};

--- a/test/ErrorMessage.test.tsx
+++ b/test/ErrorMessage.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+expect.extend(toHaveNoViolations);
+
+import { ErrorMessage, Card, Text, Divider, Button } from '../src';
+
+describe('ErrorMessage', () => {
+    it('should comply with WCAG 2.0', async () => {
+        // given
+        const { container: hiddenErrorMessage } = render(
+            <ErrorMessage id="error">Message</ErrorMessage>
+        );
+        const { container: visibleErrorMessage } = render(
+            <ErrorMessage id="error" active>
+                Message
+            </ErrorMessage>
+        );
+        const { container: hiddenErrorMessageUse } = render(
+            <Card>
+                <Text header={3}>Something will happen if you click the button!</Text>
+                <Divider />
+                <Text>Click it</Text>
+                <br />
+                <Button aria-errorMessage="click-error">Click me :)</Button>
+                <ErrorMessage id="click-error">Nothing Happened :/</ErrorMessage>
+            </Card>
+        );
+        const { container: visibleErrorMessageUse } = render(
+            <Card>
+                <Text header={3}>Something will happen if you click the button!</Text>
+                <Divider />
+                <Text>Click it</Text>
+                <br />
+                <Button aria-errorMessage="click-error">Click me :)</Button>
+                <ErrorMessage id="click-error" active>
+                    Nothing Happened :/
+                </ErrorMessage>
+            </Card>
+        );
+
+        // when
+        const results = [];
+        results.push(await axe(hiddenErrorMessage));
+        results.push(await axe(visibleErrorMessage));
+        results.push(await axe(hiddenErrorMessageUse));
+        results.push(await axe(visibleErrorMessageUse));
+
+        // then
+        results.forEach((result: any) => {
+            expect(result).toHaveNoViolations();
+        });
+    });
+
+    it('should render when active', () => {
+        // given
+        render(
+            <ErrorMessage id="error" active>
+                Not hidden
+            </ErrorMessage>
+        );
+
+        // when then
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    it('should render correctly', () => {
+        // given
+        render(
+            <ErrorMessage id="error" active>
+                Not hidden
+            </ErrorMessage>
+        );
+
+        // when then
+        expect(screen.getByText(/not hidden/i)).toBeInTheDocument();
+    });
+
+    it('should not render when inactive', () => {
+        // given
+        render(<ErrorMessage id="error">Not hidden</ErrorMessage>);
+
+        // when then
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
# Added Error Message Component
Added the error mesage to Apollo.
- https://linear.app/milemarker10/issue/MIL-646/feature-errormessage-component

## Purpose
Purpose of this PR is to create an  error mesage to create uniform error alerts that are both accessible and compliant to Apollo standards.

## Summary of Changes
Here I just created the component, added its documentation and corresponding testing all while ensuring accessibility is up to par. Finally the following files had their code updated to use the `ErrorMessage`

- TextInput
- Group
- Checkbox
- Radio

# Certificate
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.